### PR TITLE
feat: Invite players to team

### DIFF
--- a/src/MercuriusAPI/Controllers/LAN/TeamsController.cs
+++ b/src/MercuriusAPI/Controllers/LAN/TeamsController.cs
@@ -111,8 +111,7 @@ namespace MercuriusAPI.Controllers.LAN
         [HttpPut("{id}/players/invite/{playerId}")]
         public async Task<TeamInviteDTO> RespondToInviteAsync(int id, int playerId, [FromBody] RespondTeamInviteDTO dto)
         {
-            var player = await _playerService.GetPlayerByIdAsync(playerId);
-            return await _teamService.RespondToInviteAsync(id, player, dto.Accept);
+            return await _teamService.RespondToInviteAsync(id, playerId, dto.Accept);
         }
 
         /// <summary>

--- a/src/MercuriusAPI/Controllers/LAN/TeamsController.cs
+++ b/src/MercuriusAPI/Controllers/LAN/TeamsController.cs
@@ -48,19 +48,6 @@ namespace MercuriusAPI.Controllers.LAN
         }
 
         /// <summary>
-        /// Adds a player to a team.
-        /// </summary>
-        /// <param name="id">The team ID.</param>
-        /// <param name="playerId">The player ID.</param>
-        /// <returns>The updated team with the new player.</returns>
-        [HttpPut("{id}/players/{playerId}")]
-        public async Task<GetTeamDTO> AddPlayerAsync(int id, int playerId)
-        {
-            var player = await _playerService.GetPlayerByIdAsync(playerId);
-            return await _teamService.AddPlayerAsync(id, player);
-        }
-
-        /// <summary>
         /// Removes a player from a team.
         /// </summary>
         /// <param name="id">The team ID.</param>

--- a/src/MercuriusAPI/Controllers/LAN/TeamsController.cs
+++ b/src/MercuriusAPI/Controllers/LAN/TeamsController.cs
@@ -87,5 +87,43 @@ namespace MercuriusAPI.Controllers.LAN
         {
             return _teamService.DeleteTeamAsync(id);
         }
+
+        /// <summary>
+        /// Invites a player to join a team. Only the team captain can send invites. If the player accepts, they will be added to the team.
+        /// </summary>
+        /// <param name="id">The ID of the team sending the invitation.</param>
+        /// <param name="playerId">The ID of the player to invite.</param>
+        /// <returns>The created team invitation details.</returns>
+        [HttpPost("{id}/players/invite/{playerId}")]
+        public async Task<TeamInviteDTO> InvitePlayerAsync(int id, int playerId)
+        {
+            return await _teamService.InvitePlayerAsync(id, playerId);
+        }
+
+        /// <summary>
+        /// Allows a player to respond to a team invitation. The player can accept or decline the invitation.
+        /// If accepted, the player is added to the team. If declined, the invitation is marked as declined.
+        /// </summary>
+        /// <param name="id">The ID of the team that sent the invitation.</param>
+        /// <param name="playerId">The ID of the player responding to the invitation.</param>
+        /// <param name="dto">The response indicating acceptance or decline.</param>
+        /// <returns>The updated team invitation details.</returns>
+        [HttpPut("{id}/players/invite/{playerId}")]
+        public async Task<TeamInviteDTO> RespondToInviteAsync(int id, int playerId, [FromBody] RespondTeamInviteDTO dto)
+        {
+            var player = await _playerService.GetPlayerByIdAsync(playerId);
+            return await _teamService.RespondToInviteAsync(id, player, dto.Accept);
+        }
+
+        /// <summary>
+        /// Retrieves all pending team invitations for a specific player.
+        /// </summary>
+        /// <param name="playerId">The ID of the player whose invitations are being retrieved.</param>
+        /// <returns>A list of pending team invitations for the player.</returns>
+        [HttpGet("players/{playerId}/invites")]
+        public async Task<IEnumerable<TeamInviteDTO>> GetPlayerInvitesAsync(int playerId)
+        {
+            return await _teamService.GetPlayerInvitesAsync(playerId);
+        }
     }
 }

--- a/src/MercuriusAPI/DTOs/LAN/TeamDTOs/GetTeamDTO.cs
+++ b/src/MercuriusAPI/DTOs/LAN/TeamDTOs/GetTeamDTO.cs
@@ -9,11 +9,13 @@ namespace MercuriusAPI.DTOs.LAN.TeamDTOs
         public string Name { get; set; }
         public int CaptainId { get; set; }
         public IEnumerable<GetTeamPlayerDTO> Players { get; set; } = [];
+        public IEnumerable<TeamInviteDTO> TeamInvites { get; set; } = [];
         public GetTeamDTO(Team team)
         {
             Id = team.Id;
             Name = team.Name;
             Players = team.Players.Select(p => new GetTeamPlayerDTO(p));
+            TeamInvites = team.TeamInvites.Where(i => i.Status == TeamInviteStatus.Pending).Select(i => new TeamInviteDTO(i));
             CaptainId = team.CaptainId;
         }
     }

--- a/src/MercuriusAPI/DTOs/LAN/TeamDTOs/TeamInviteDTO.cs
+++ b/src/MercuriusAPI/DTOs/LAN/TeamDTOs/TeamInviteDTO.cs
@@ -1,5 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
-Add commentMore actions
+﻿using MercuriusAPI.Models.LAN;
+using System.ComponentModel.DataAnnotations;
 
 namespace MercuriusAPI.DTOs.LAN.TeamDTOs
 {
@@ -11,6 +11,21 @@ namespace MercuriusAPI.DTOs.LAN.TeamDTOs
         public string Status { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime? RespondedAt { get; set; }
+
+        public TeamInviteDTO()
+        {
+           
+        }
+
+        public TeamInviteDTO(TeamInvite teamInvite)
+        {
+            Id = teamInvite.Id;
+            TeamId = teamInvite.TeamId;
+            PlayerId = teamInvite.PlayerId;
+            Status = teamInvite.Status.ToString();
+            CreatedAt = teamInvite.CreatedAt;
+            RespondedAt = teamInvite.RespondedAt;
+        }
     }
 
     public class CreateTeamInviteDTO

--- a/src/MercuriusAPI/DTOs/LAN/TeamDTOs/TeamInviteDTO.cs
+++ b/src/MercuriusAPI/DTOs/LAN/TeamDTOs/TeamInviteDTO.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel.DataAnnotations;
+Add commentMore actions
+
+namespace MercuriusAPI.DTOs.LAN.TeamDTOs
+{
+    public class TeamInviteDTO
+    {
+        public int Id { get; set; }
+        public int TeamId { get; set; }
+        public int PlayerId { get; set; }
+        public string Status { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? RespondedAt { get; set; }
+    }
+
+    public class CreateTeamInviteDTO
+    {
+        [Required]
+        public int TeamId { get; set; }
+        [Required]
+        public int PlayerId { get; set; }
+    }
+
+    public class RespondTeamInviteDTO
+    {
+        [Required]
+        public bool Accept { get; set; }
+    }
+}

--- a/src/MercuriusAPI/Data/MercuriusDBContext.cs
+++ b/src/MercuriusAPI/Data/MercuriusDBContext.cs
@@ -18,6 +18,7 @@ namespace MercuriusAPI.Data
         public DbSet<Match> Matches { get; set; }
         public DbSet<Game> Games { get; set; }
         public DbSet<Participant> Participants { get; set; }
+        public DbSet<TeamInvite> TeamInvites { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -78,6 +79,21 @@ namespace MercuriusAPI.Data
                 entity.Property(e => e.EndTime).IsRequired();
                 entity.HasMany(e => e.Participants)
                       .WithMany(e => e.Games);
+            });
+
+            modelBuilder.Entity<TeamInvite>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.HasOne(e => e.Team)
+                      .WithMany()
+                      .HasForeignKey(e => e.TeamId)
+                      .OnDelete(DeleteBehavior.Cascade);
+                entity.HasOne(e => e.Player)
+                      .WithMany()
+                      .HasForeignKey(e => e.PlayerId)
+                      .OnDelete(DeleteBehavior.Cascade);
+                entity.Property(e => e.Status).IsRequired();
+                entity.Property(e => e.CreatedAt).IsRequired();
             });
 
             OnModelCreatingPartial(modelBuilder);

--- a/src/MercuriusAPI/Data/MercuriusDBContext.cs
+++ b/src/MercuriusAPI/Data/MercuriusDBContext.cs
@@ -85,7 +85,7 @@ namespace MercuriusAPI.Data
             {
                 entity.HasKey(e => e.Id);
                 entity.HasOne(e => e.Team)
-                      .WithMany()
+                      .WithMany(t => t.TeamInvites)
                       .HasForeignKey(e => e.TeamId)
                       .OnDelete(DeleteBehavior.Cascade);
                 entity.HasOne(e => e.Player)

--- a/src/MercuriusAPI/Extensions/ConfigureSwaggerOptions.cs
+++ b/src/MercuriusAPI/Extensions/ConfigureSwaggerOptions.cs
@@ -38,7 +38,7 @@ namespace MercuriusAPI.Extensions
         /// </summary>
         /// <param name="name"></param>
         /// <param name="options"></param>
-        public void Configure(string name, SwaggerGenOptions options)
+        public void Configure(string? name, SwaggerGenOptions options)
         {
             Configure(options);
         }
@@ -46,7 +46,6 @@ namespace MercuriusAPI.Extensions
         /// <summary>
         /// Create information about the version of the API
         /// </summary>
-        /// <param name="description"></param>
         /// <returns>Information about the API</returns>
         private OpenApiInfo CreateVersionInfo(
                 ApiVersionDescription desc)

--- a/src/MercuriusAPI/MercuriusAPI.csproj
+++ b/src/MercuriusAPI/MercuriusAPI.csproj
@@ -8,6 +8,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 		<DockerfileContext>.</DockerfileContext>
+		<NoWarn>CS1591;CS8602;CS8618</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -24,5 +25,4 @@
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
 	</ItemGroup>
-
 </Project>

--- a/src/MercuriusAPI/Migrations/20250603120000_AddTeamInvite.cs
+++ b/src/MercuriusAPI/Migrations/20250603120000_AddTeamInvite.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+
+namespace MercuriusAPI.Migrations
+{
+    public partial class AddTeamInvite : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TeamInvites",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TeamId = table.Column<int>(nullable: false),
+                    PlayerId = table.Column<int>(nullable: false),
+                    CreatedAt = table.Column<DateTime>(nullable: false),
+                    Status = table.Column<int>(nullable: false),
+                    RespondedAt = table.Column<DateTime>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeamInvites", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TeamInvites_Teams_TeamId",
+                        column: x => x.TeamId,
+                        principalTable: "Teams",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TeamInvites_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamInvites_TeamId",
+                table: "TeamInvites",
+                column: "TeamId");
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamInvites_PlayerId",
+                table: "TeamInvites",
+                column: "PlayerId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TeamInvites");
+        }
+    }
+}

--- a/src/MercuriusAPI/Migrations/MercuriusDBContextModelSnapshot.cs
+++ b/src/MercuriusAPI/Migrations/MercuriusDBContextModelSnapshot.cs
@@ -194,6 +194,38 @@ namespace MercuriusAPI.Migrations
                     b.ToTable("Placement");
                 });
 
+            modelBuilder.Entity("MercuriusAPI.Models.LAN.TeamInvite", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("PlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTime?>("RespondedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("TeamId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("PlayerId");
+
+                    b.HasIndex("TeamId");
+
+                    b.ToTable("TeamInvites");
+                });
+
             modelBuilder.Entity("PlayerTeam", b =>
                 {
                     b.Property<int>("PlayersId")
@@ -335,6 +367,25 @@ namespace MercuriusAPI.Migrations
                         .IsRequired();
                 });
 
+            modelBuilder.Entity("MercuriusAPI.Models.LAN.TeamInvite", b =>
+                {
+                    b.HasOne("MercuriusAPI.Models.LAN.Player", "Player")
+                        .WithMany()
+                        .HasForeignKey("PlayerId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("MercuriusAPI.Models.LAN.Team", "Team")
+                        .WithMany("TeamInvites")
+                        .HasForeignKey("TeamId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Player");
+
+                    b.Navigation("Team");
+                });
+
             modelBuilder.Entity("PlayerTeam", b =>
                 {
                     b.HasOne("MercuriusAPI.Models.LAN.Player", null)
@@ -386,6 +437,11 @@ namespace MercuriusAPI.Migrations
             modelBuilder.Entity("MercuriusAPI.Models.LAN.Placement", b =>
                 {
                     b.Navigation("Participants");
+                });
+
+            modelBuilder.Entity("MercuriusAPI.Models.LAN.Team", b =>
+                {
+                    b.Navigation("TeamInvites");
                 });
 #pragma warning restore 612, 618
         }

--- a/src/MercuriusAPI/Models/LAN/Team.cs
+++ b/src/MercuriusAPI/Models/LAN/Team.cs
@@ -1,4 +1,5 @@
 ﻿using MercuriusAPI.Exceptions;
+using Microsoft.EntityFrameworkCore;
 
 namespace MercuriusAPI.Models.LAN
 {
@@ -8,6 +9,7 @@ namespace MercuriusAPI.Models.LAN
         public Player Captain { get; set; }
 
         public IList<Player> Players { get; set; } = new List<Player>();
+        public IList<TeamInvite> TeamInvites { get; set; } = new List<TeamInvite>();
 
         public Team()
         {
@@ -27,7 +29,11 @@ namespace MercuriusAPI.Models.LAN
             if(name is not null)
                 Name = name;
             if(captainId is not null)
-            CaptainId = (int)captainId;
+            {
+                if(!Players.Any(m => m.Id == captainId))
+                    throw new ValidationException($"New captain must be part of the team.");
+                CaptainId = (int)captainId;
+            }
         }
 
         public void RemovePlayer(int playerId)
@@ -38,6 +44,29 @@ namespace MercuriusAPI.Models.LAN
             if(player.Id == CaptainId)
                 throw new ValidationException("The captain cannot be removed from a team");
             Players.Remove(player);
+        }
+
+        public TeamInvite InvitePlayer(int playerId, int inviteResendCooldownDays)
+        {
+            if(Players.Any(p => p.Id == playerId))
+                throw new ValidationException("Player is already in the team");
+            if(TeamInvites.Any(i => i.PlayerId == playerId && i.Status == TeamInviteStatus.Pending))
+                throw new ValidationException("Player already has a pending invite to this team");
+            var lastDeclinedInvite = TeamInvites
+               .Where(i => i.PlayerId == playerId && i.Status == TeamInviteStatus.Declined)
+               .OrderByDescending(i => i.RespondedAt)
+               .FirstOrDefault();
+            if(lastDeclinedInvite != null && lastDeclinedInvite.RespondedAt.HasValue)
+            {
+                var daysSinceDeclined = (DateTime.UtcNow - lastDeclinedInvite.RespondedAt.Value).TotalDays;
+                if(daysSinceDeclined < inviteResendCooldownDays)
+                {
+                    throw new ValidationException($"Player declined the last invite less than {inviteResendCooldownDays} days ago. Please wait {inviteResendCooldownDays - (int)daysSinceDeclined} more day(s).");
+                }
+            }
+            var invite = new TeamInvite { TeamId = Id, PlayerId = playerId };
+            TeamInvites.Add(invite);
+            return invite;
         }
     }
 }

--- a/src/MercuriusAPI/Models/LAN/TeamInvite.cs
+++ b/src/MercuriusAPI/Models/LAN/TeamInvite.cs
@@ -20,5 +20,16 @@ namespace MercuriusAPI.Models.LAN
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public TeamInviteStatus Status { get; set; } = TeamInviteStatus.Pending;
         public DateTime? RespondedAt { get; set; }
+
+        public void Respond(bool accept)
+        {
+            if(Status != TeamInviteStatus.Pending)
+                throw new InvalidOperationException("Cannot respond to an invite that is not pending.");
+
+            Status = accept ? TeamInviteStatus.Accepted : TeamInviteStatus.Declined;
+            if(accept)
+                Team.Players.Add(Player);
+            RespondedAt = DateTime.UtcNow;
+        }
     }
 }

--- a/src/MercuriusAPI/Models/LAN/TeamInvite.cs
+++ b/src/MercuriusAPI/Models/LAN/TeamInvite.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using MercuriusAPI.Exceptions;
 using MercuriusAPI.Models.LAN;
 
 namespace MercuriusAPI.Models.LAN
@@ -24,7 +25,7 @@ namespace MercuriusAPI.Models.LAN
         public void Respond(bool accept)
         {
             if(Status != TeamInviteStatus.Pending)
-                throw new InvalidOperationException("Cannot respond to an invite that is not pending.");
+                throw new ValidationException("Cannot respond to an invite that is not pending.");
 
             Status = accept ? TeamInviteStatus.Accepted : TeamInviteStatus.Declined;
             if(accept)

--- a/src/MercuriusAPI/Models/LAN/TeamInvite.cs
+++ b/src/MercuriusAPI/Models/LAN/TeamInvite.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using MercuriusAPI.Models.LAN;
+
+namespace MercuriusAPI.Models.LAN
+{
+    public enum TeamInviteStatus
+    {
+        Pending,
+        Accepted,
+        Declined
+    }
+
+    public class TeamInvite
+    {
+        public int Id { get; set; }
+        public int TeamId { get; set; }
+        public Team Team { get; set; }
+        public int PlayerId { get; set; }
+        public Player Player { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public TeamInviteStatus Status { get; set; } = TeamInviteStatus.Pending;
+        public DateTime? RespondedAt { get; set; }
+    }
+}

--- a/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/DoubleEliminationMatchModerator.cs
+++ b/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/DoubleEliminationMatchModerator.cs
@@ -1,4 +1,5 @@
-﻿using MercuriusAPI.Extensions.LAN;
+﻿using MercuriusAPI.Exceptions;
+using MercuriusAPI.Extensions.LAN;
 using MercuriusAPI.Models.LAN;
 using MercuriusAPI.Services.LAN.MatchServices.Helpers;
 using System.Linq;
@@ -216,6 +217,11 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
                 .OrderByDescending(m => m.RoundNumber)
                 .ThenByDescending(m => m.MatchNumber)
                 .FirstOrDefault();
+
+            if(grandFinal.Winner is null)
+                throw new ValidationException("Grand final match has no winner assigned. Cannot determine placements.");
+            if(grandFinal.Loser is null)
+                throw new ValidationException("Grand final match has no loser assigned. Cannot determine placements.");
 
             game.Placements.Add(new Placement
             {

--- a/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/RoundRobinMatchModerator.cs
+++ b/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/RoundRobinMatchModerator.cs
@@ -66,7 +66,7 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
         {
             var matches = new List<Match>();
 
-            var rotation = new List<Participant>(game.Participants);
+            var rotation = new List<Participant?>(game.Participants);
             bool isOdd = rotation.Count % 2 != 0;
             if(isOdd)
                 rotation.Add(null);

--- a/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/SingleEliminationMatchModerator.cs
+++ b/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/SingleEliminationMatchModerator.cs
@@ -1,4 +1,5 @@
-﻿using MercuriusAPI.Extensions.LAN;
+﻿using MercuriusAPI.Exceptions;
+using MercuriusAPI.Extensions.LAN;
 using MercuriusAPI.Models.LAN;
 using MercuriusAPI.Services.LAN.MatchServices.Helpers;
 using System.Linq;
@@ -17,6 +18,8 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
                 .OrderByDescending(m => m.RoundNumber)
                 .ThenByDescending(m => m.MatchNumber)
                 .FirstOrDefault();
+            if(finalMatch.Winner is null)
+                throw new ValidationException("Final match has no winner assigned.");
 
             game.Placements.Add(new Placement
             {

--- a/src/MercuriusAPI/Services/LAN/TeamServices/ITeamService.cs
+++ b/src/MercuriusAPI/Services/LAN/TeamServices/ITeamService.cs
@@ -5,7 +5,6 @@ namespace MercuriusAPI.Services.LAN.TeamServices
 {
     public interface ITeamService
     {
-        Task<GetTeamDTO> AddPlayerAsync(int id, Player player);
         Task<GetTeamDTO> CreateTeamAsync(CreateTeamDTO teamDTO, Player player);
         Task DeleteTeamAsync(int teamId);
         IEnumerable<GetTeamDTO> GetAllTeams();

--- a/src/MercuriusAPI/Services/LAN/TeamServices/ITeamService.cs
+++ b/src/MercuriusAPI/Services/LAN/TeamServices/ITeamService.cs
@@ -9,8 +9,11 @@ namespace MercuriusAPI.Services.LAN.TeamServices
         Task<GetTeamDTO> CreateTeamAsync(CreateTeamDTO teamDTO, Player player);
         Task DeleteTeamAsync(int teamId);
         IEnumerable<GetTeamDTO> GetAllTeams();
+        Task<IEnumerable<TeamInviteDTO>> GetPlayerInvitesAsync(int playerId);
         Task<Team> GetTeamByIdAsync(int teamId);
+        Task<TeamInviteDTO> InvitePlayerAsync(int teamId, int playerId);
         Task<GetTeamDTO> RemovePlayerAsync(int id, int playerId);
+        Task<TeamInviteDTO> RespondToInviteAsync(int teamId, int playerId, bool accept);
         Task<GetTeamDTO> UpdateTeamAsync(int id, UpdateTeamDTO teamDTO);
     }
 }

--- a/src/MercuriusAPI/Services/LAN/TeamServices/TeamService.cs
+++ b/src/MercuriusAPI/Services/LAN/TeamServices/TeamService.cs
@@ -20,7 +20,7 @@ namespace MercuriusAPI.Services.LAN.TeamServices
         public async Task<GetTeamDTO> CreateTeamAsync(CreateTeamDTO teamDTO, Player captain)
         {
             if(await CheckIfTeamNameExistsAsync(teamDTO.Name))
-                throw new ValidationException($"Teamname {teamDTO.Name} already in use");            
+                throw new ValidationException($"Teamname {teamDTO.Name} already in use");
             var team = new Team(teamDTO.Name, captain);
             _dbContext.Teams.Add(team);
             await _dbContext.SaveChangesAsync();
@@ -80,63 +80,23 @@ namespace MercuriusAPI.Services.LAN.TeamServices
 
         public async Task<TeamInviteDTO> InvitePlayerAsync(int teamId, int playerId)
         {
-            var team = await _dbContext.Teams.Include(t => t.Players).FirstOrDefaultAsync(t => t.Id == teamId);
-            if (team == null) throw new NotFoundException($"{nameof(Team)} not found");
-            if (team.Players.Any(p => p.Id == playerId)) throw new ValidationException("Player is already in the team");
-
-            // Check for pending invite
-            var existingPendingInvite = await _dbContext.TeamInvites.FirstOrDefaultAsync(i => i.TeamId == teamId && i.PlayerId == playerId && i.Status == TeamInviteStatus.Pending);
-            if (existingPendingInvite != null) throw new ValidationException("There is already a pending invite for this player");
-
-            // Check for last declined invite
-            var lastDeclinedInvite = await _dbContext.TeamInvites
-                .Where(i => i.TeamId == teamId && i.PlayerId == playerId && i.Status == TeamInviteStatus.Declined)
-                .OrderByDescending(i => i.RespondedAt)
-                .FirstOrDefaultAsync();
-            if (lastDeclinedInvite != null && lastDeclinedInvite.RespondedAt.HasValue)
-            {
-                var daysSinceDeclined = (DateTime.UtcNow - lastDeclinedInvite.RespondedAt.Value).TotalDays;
-                if (daysSinceDeclined < _inviteResendCooldownDays)
-                {
-                    throw new ValidationException($"Player declined the last invite less than {_inviteResendCooldownDays} days ago. Please wait {_inviteResendCooldownDays - (int)daysSinceDeclined} more day(s).");
-                }
-            }
-
-            var invite = new TeamInvite { TeamId = teamId, PlayerId = playerId };
-            _dbContext.TeamInvites.Add(invite);
+            var team = await GetTeamByIdAsync(teamId);
+            await _dbContext.Entry(team).Collection(t => t.TeamInvites).LoadAsync();
+            if(team == null)
+                throw new NotFoundException($"{nameof(Team)} not found");
+            var invite = team.InvitePlayer(playerId, _inviteResendCooldownDays);
             await _dbContext.SaveChangesAsync();
-            return new TeamInviteDTO
-            {
-                Id = invite.Id,
-                TeamId = invite.TeamId,
-                PlayerId = invite.PlayerId,
-                Status = invite.Status.ToString(),
-                CreatedAt = invite.CreatedAt
-            };
+            return new TeamInviteDTO(invite);
         }
 
-        public async Task<TeamInviteDTO> RespondToInviteAsync(int teamId, Player player, bool accept)
+        public async Task<TeamInviteDTO> RespondToInviteAsync(int teamId, int playerId, bool accept)
         {
-            var invite = await _dbContext.TeamInvites.FirstOrDefaultAsync(i => i.TeamId == teamId && i.PlayerId == player.Id && i.Status == TeamInviteStatus.Pending);
-            if (invite == null) throw new NotFoundException("Invite not found");
-            invite.Status = accept ? TeamInviteStatus.Accepted : TeamInviteStatus.Declined;
-            invite.RespondedAt = DateTime.UtcNow;
-            if (accept)
-            {
-                var team = await _dbContext.Teams.Include(t => t.Players).FirstOrDefaultAsync(t => t.Id == teamId);
-                if (team == null) throw new NotFoundException("Team not found");
-                team.Players.Add(player);
-            }
+            var invite = await _dbContext.TeamInvites.FirstOrDefaultAsync(i => i.TeamId == teamId && i.PlayerId == playerId && i.Status == TeamInviteStatus.Pending);
+            if(invite == null)
+                throw new NotFoundException("No pending invite not found");
+            invite.Respond(accept);
             await _dbContext.SaveChangesAsync();
-            return new TeamInviteDTO
-            {
-                Id = invite.Id,
-                TeamId = invite.TeamId,
-                PlayerId = invite.PlayerId,
-                Status = invite.Status.ToString(),
-                CreatedAt = invite.CreatedAt,
-                RespondedAt = invite.RespondedAt
-            };
+            return new TeamInviteDTO(invite);
         }
 
         public async Task<IEnumerable<TeamInviteDTO>> GetPlayerInvitesAsync(int playerId)

--- a/src/MercuriusAPI/Services/LAN/TeamServices/TeamService.cs
+++ b/src/MercuriusAPI/Services/LAN/TeamServices/TeamService.cs
@@ -3,15 +3,18 @@ using MercuriusAPI.DTOs.LAN.TeamDTOs;
 using MercuriusAPI.Exceptions;
 using MercuriusAPI.Models.LAN;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace MercuriusAPI.Services.LAN.TeamServices
 {
     public class TeamService : ITeamService
     {
         private readonly MercuriusDBContext _dbContext;
-        public TeamService(MercuriusDBContext dbContext)
+        private readonly int _inviteResendCooldownDays;
+        public TeamService(MercuriusDBContext dbContext, IConfiguration configuration)
         {
             _dbContext = dbContext;
+            _inviteResendCooldownDays = configuration.GetSection("TeamInvite:ResendCooldownDays").Get<int>();
         }
 
         public async Task<GetTeamDTO> CreateTeamAsync(CreateTeamDTO teamDTO, Player captain)
@@ -73,6 +76,80 @@ namespace MercuriusAPI.Services.LAN.TeamServices
             _dbContext.Teams.Update(team);
             await _dbContext.SaveChangesAsync();
             return new GetTeamDTO(team);
+        }
+
+        public async Task<TeamInviteDTO> InvitePlayerAsync(int teamId, int playerId)
+        {
+            var team = await _dbContext.Teams.Include(t => t.Players).FirstOrDefaultAsync(t => t.Id == teamId);
+            if (team == null) throw new NotFoundException($"{nameof(Team)} not found");
+            if (team.Players.Any(p => p.Id == playerId)) throw new ValidationException("Player is already in the team");
+
+            // Check for pending invite
+            var existingPendingInvite = await _dbContext.TeamInvites.FirstOrDefaultAsync(i => i.TeamId == teamId && i.PlayerId == playerId && i.Status == TeamInviteStatus.Pending);
+            if (existingPendingInvite != null) throw new ValidationException("There is already a pending invite for this player");
+
+            // Check for last declined invite
+            var lastDeclinedInvite = await _dbContext.TeamInvites
+                .Where(i => i.TeamId == teamId && i.PlayerId == playerId && i.Status == TeamInviteStatus.Declined)
+                .OrderByDescending(i => i.RespondedAt)
+                .FirstOrDefaultAsync();
+            if (lastDeclinedInvite != null && lastDeclinedInvite.RespondedAt.HasValue)
+            {
+                var daysSinceDeclined = (DateTime.UtcNow - lastDeclinedInvite.RespondedAt.Value).TotalDays;
+                if (daysSinceDeclined < _inviteResendCooldownDays)
+                {
+                    throw new ValidationException($"Player declined the last invite less than {_inviteResendCooldownDays} days ago. Please wait {_inviteResendCooldownDays - (int)daysSinceDeclined} more day(s).");
+                }
+            }
+
+            var invite = new TeamInvite { TeamId = teamId, PlayerId = playerId };
+            _dbContext.TeamInvites.Add(invite);
+            await _dbContext.SaveChangesAsync();
+            return new TeamInviteDTO
+            {
+                Id = invite.Id,
+                TeamId = invite.TeamId,
+                PlayerId = invite.PlayerId,
+                Status = invite.Status.ToString(),
+                CreatedAt = invite.CreatedAt
+            };
+        }
+
+        public async Task<TeamInviteDTO> RespondToInviteAsync(int teamId, Player player, bool accept)
+        {
+            var invite = await _dbContext.TeamInvites.FirstOrDefaultAsync(i => i.TeamId == teamId && i.PlayerId == player.Id && i.Status == TeamInviteStatus.Pending);
+            if (invite == null) throw new NotFoundException("Invite not found");
+            invite.Status = accept ? TeamInviteStatus.Accepted : TeamInviteStatus.Declined;
+            invite.RespondedAt = DateTime.UtcNow;
+            if (accept)
+            {
+                var team = await _dbContext.Teams.Include(t => t.Players).FirstOrDefaultAsync(t => t.Id == teamId);
+                if (team == null) throw new NotFoundException("Team not found");
+                team.Players.Add(player);
+            }
+            await _dbContext.SaveChangesAsync();
+            return new TeamInviteDTO
+            {
+                Id = invite.Id,
+                TeamId = invite.TeamId,
+                PlayerId = invite.PlayerId,
+                Status = invite.Status.ToString(),
+                CreatedAt = invite.CreatedAt,
+                RespondedAt = invite.RespondedAt
+            };
+        }
+
+        public async Task<IEnumerable<TeamInviteDTO>> GetPlayerInvitesAsync(int playerId)
+        {
+            var invites = await _dbContext.TeamInvites.Where(i => i.PlayerId == playerId && i.Status == TeamInviteStatus.Pending).ToListAsync();
+            return invites.Select(invite => new TeamInviteDTO
+            {
+                Id = invite.Id,
+                TeamId = invite.TeamId,
+                PlayerId = invite.PlayerId,
+                Status = invite.Status.ToString(),
+                CreatedAt = invite.CreatedAt
+            });
         }
 
         private Task<bool> CheckIfTeamNameExistsAsync(string name)

--- a/src/MercuriusAPI/Services/LAN/TeamServices/TeamService.cs
+++ b/src/MercuriusAPI/Services/LAN/TeamServices/TeamService.cs
@@ -91,7 +91,7 @@ namespace MercuriusAPI.Services.LAN.TeamServices
 
         public async Task<TeamInviteDTO> RespondToInviteAsync(int teamId, int playerId, bool accept)
         {
-            var invite = await _dbContext.TeamInvites.FirstOrDefaultAsync(i => i.TeamId == teamId && i.PlayerId == playerId && i.Status == TeamInviteStatus.Pending);
+            var invite = await _dbContext.TeamInvites.Include(ti => ti.Player).Include(ti => ti.Team).FirstOrDefaultAsync(i => i.TeamId == teamId && i.PlayerId == playerId && i.Status == TeamInviteStatus.Pending);
             if(invite == null)
                 throw new NotFoundException("No pending invite not found");
             invite.Respond(accept);

--- a/src/MercuriusAPI/Services/LAN/TeamServices/TeamService.cs
+++ b/src/MercuriusAPI/Services/LAN/TeamServices/TeamService.cs
@@ -57,16 +57,6 @@ namespace MercuriusAPI.Services.LAN.TeamServices
             return new GetTeamDTO(team);
         }
 
-        public async Task<GetTeamDTO> AddPlayerAsync(int id, Player player)
-        {
-            var team = await _dbContext.Teams.Include(t => t.Players).FirstOrDefaultAsync(t => t.Id == id);
-            if(team is null)
-                throw new NotFoundException($"{nameof(Team)} not found");
-            team.Players.Add(player);
-            await _dbContext.SaveChangesAsync();
-            return new GetTeamDTO(team);
-        }
-
         public async Task<GetTeamDTO> UpdateTeamAsync(int id, UpdateTeamDTO teamDTO)
         {
             var team = await GetTeamByIdAsync(id);

--- a/src/MercuriusAPI/Services/LAN/TeamServices/TeamService.cs
+++ b/src/MercuriusAPI/Services/LAN/TeamServices/TeamService.cs
@@ -83,7 +83,7 @@ namespace MercuriusAPI.Services.LAN.TeamServices
         {
             var invite = await _dbContext.TeamInvites.Include(ti => ti.Player).Include(ti => ti.Team).FirstOrDefaultAsync(i => i.TeamId == teamId && i.PlayerId == playerId && i.Status == TeamInviteStatus.Pending);
             if(invite == null)
-                throw new NotFoundException("No pending invite not found");
+                throw new NotFoundException("No pending invite found");
             invite.Respond(accept);
             await _dbContext.SaveChangesAsync();
             return new TeamInviteDTO(invite);

--- a/src/MercuriusAPI/appsettings.Development.json
+++ b/src/MercuriusAPI/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "TeamInvite": {
+    "ResendCooldownDays": 3
   }
 }

--- a/src/MercuriusAPI/appsettings.json
+++ b/src/MercuriusAPI/appsettings.json
@@ -8,5 +8,8 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "MercuriusDB": "Server=localhost;Port=5432;Username=postgres;Database=mercuriusdb"
+  },
+  "TeamInvite": {
+    "ResendCooldownDays": 3
   }
 }


### PR DESCRIPTION
### feat: Implemented Invite players to team feature
Closes #5 
---

### **1. What does this PR do?**

- Implements the functionality to invite players into a team rather then directly adding them (without the player's consent).
- Fixes a small bug when updating the captain that previously did not check if the new captain was part of the team.

### **2. Why is this change necessary?**

Previous implementation of adding players to a team didn't require the player's consent and just added him/her to the team.

### **3. How was it implemented? (Technical Details)**

- A new model "TeamInvite" has been created. It has a relation to the Team it got sent from and the player it got sent to.
- Send and update invite endpoints are created: **POST lan/teams/{id}/players/invite/{playerId}** and **PUT lan/teams/{id}/players/invite/{playerId}**
- New endpoint to fetch all invites for a user: **GET lan/teams/players/{playerId}/invites**
- Previous add player to team endpoint **POST lan/team/{id}/players/{playerId}** has been removed
- All Team endpoint with "GetTeamDTO" result will now include all pending invites from the Team.

TeamInvite "requirements"/ configuration:
An invite can only be sent to players that:
- Are not yet in the team
- Haven't declined a previous invitation within the configured cooldown
- Have no current pending invitation for the same team
