### PR TITLE
ci: add Dockerfile trigger path

### DIFF
--- a/.github/workflows/ci-application.yml
+++ b/.github/workflows/ci-application.yml
@@ -7,6 +7,7 @@ on:
     - main
     paths: 
     - src/**
+    - Dockerfile
     types: 
     - opened
     - synchronize


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci-application.yml` file. The change updates the workflow trigger by adding `Dockerfile` to the list of paths that will trigger the workflow.