### PR TITLE
ci: add code checkout step

### DIFF
--- a/.github/workflows/ci-application.yml
+++ b/.github/workflows/ci-application.yml
@@ -28,7 +28,7 @@ jobs:
     name: "Build Application"
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
@@ -48,6 +48,9 @@ jobs:
     runs-on: ubuntu-24.04
     name: "Build Docker Image"
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
     - name: Create image
       run: |
           docker build \


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use the latest versions of actions and adds a missing checkout step to the Docker image build job.

Workflow updates:

* [`.github/workflows/ci-application.yml`](diffhunk://#diff-9af3aef6896bc42e496b26b00d5dc67d93b92ac8b1471cf541408a53ac7dfb2dL31-R31): Updated the `actions/checkout` step to use version `v4` in the "Build Application" job.
* [`.github/workflows/ci-application.yml`](diffhunk://#diff-9af3aef6896bc42e496b26b00d5dc67d93b92ac8b1471cf541408a53ac7dfb2dR51-R53): Added a missing `actions/checkout@v4` step in the "Build Docker Image" job to ensure the code is checked out before building the Docker image.