### PR TITLE
ci: fix missing GITHUB_TOKEN reference

### DIFF
--- a/.github/workflows/ci-application.yml
+++ b/.github/workflows/ci-application.yml
@@ -75,9 +75,9 @@ jobs:
       uses: actions/github-script@v7.0.1
       env:
         SARIF_FILE_PATH: trivy-results.json
-        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        github-token: ${{ env.GITHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const fs = require('fs');
           const path = process.env.SARIF_FILE_PATH;


### PR DESCRIPTION
This pull request updates the CI workflow configuration to improve security by replacing the use of environment variables with GitHub secrets for token management.

Security improvements in CI workflow:

* [`.github/workflows/ci-application.yml`](diffhunk://#diff-9af3aef6896bc42e496b26b00d5dc67d93b92ac8b1471cf541408a53ac7dfb2dL78-R80): Replaced `env.GITHUB_TOKEN` with `secrets.GITHUB_TOKEN` for both the `env` and `with` sections to ensure secure handling of the GitHub token.