### PR TITLE
ci: add contents write permission

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,7 @@ env:
 
 permissions:
   id-token: write
+  contents: write
 
 jobs:      
   release-please:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/cd.yml` file. The change adds `contents: write` to the `permissions` section to enable write access to repository contents.