### PR TITLE
ci: add pull requests write permission

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,6 +14,7 @@ env:
 permissions:
   id-token: write
   contents: write
+  pull-requests: write
 
 jobs:      
   release-please:


### PR DESCRIPTION
This pull request introduces a small change to the `.github/workflows/cd.yml` file. The change adds `pull-requests: write` to the `permissions` block, granting write access to pull requests.