### PR TITLE
ci: add conditional statement to run on release created

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Build and Push Docker Image
     needs: release-please
+    if: ${{ needs.release-please.outputs.RELEASE_CREATED }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a small improvement to the continuous deployment workflow by adding a conditional check to ensure that a release is created before proceeding with the "Build and Push Docker Image" job.

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R45): Added an `if` condition to the `jobs:` section to check if `RELEASE_CREATED` is true before executing the job.