### PR TITLE
Bugfix double elimination bracket generation

### DIFF
--- a/src/MercuriusAPI/DTOs/LAN/MatchDTOs/GetMatchDTO.cs
+++ b/src/MercuriusAPI/DTOs/LAN/MatchDTOs/GetMatchDTO.cs
@@ -19,7 +19,7 @@ namespace MercuriusAPI.DTOs.LAN.MatchDTOs
         public bool IsLowerBracketMatch { get; set; }
 
         public int GameId { get; set; }
-        public int? Pariticipant1Id { get; set; }
+        public int? Participant1Id { get; set; }
         public int? Participant2Id { get; set; }
         public int? WinnerId { get; set; }
         public int? Participant1Score { get; set; }
@@ -44,11 +44,13 @@ namespace MercuriusAPI.DTOs.LAN.MatchDTOs
             MatchNumber = match.MatchNumber;
             IsLowerBracketMatch = match.IsLowerBracketMatch;
             GameId = match.GameId;
-            Pariticipant1Id = match.Pariticipant1Id;
+            Participant1Id = match.Participant1Id;
             Participant2Id = match.Participant2Id;
             WinnerId = match.WinnerId;
             Participant1Score = match.Participant1Score;
-            Participant2Score = match.Participant2Score;            
+            Participant2Score = match.Participant2Score;
+            WinnerNextMatchId = match.WinnerNextMatchId;
+            LoserNextMatchId = match.LoserNextMatchId;
         }
     }
 }

--- a/src/MercuriusAPI/DTOs/LAN/ParticipantDTOs/ParticipantDTOs.cs
+++ b/src/MercuriusAPI/DTOs/LAN/ParticipantDTOs/ParticipantDTOs.cs
@@ -1,5 +1,6 @@
 ﻿using MercuriusAPI.DTOs.LAN.PlayerDTOs;
 using MercuriusAPI.DTOs.LAN.TeamDTOs;
+using MercuriusAPI.Models.LAN;
 using System.Text.Json.Serialization;
 
 namespace MercuriusAPI.DTOs.LAN.ParticipantDTOs
@@ -8,6 +9,11 @@ namespace MercuriusAPI.DTOs.LAN.ParticipantDTOs
     [JsonDerivedType(typeof(GetTeamDTO))]
     public abstract class GetParticipantDTO
     {
+        [JsonPropertyName("$type")]
+
+        public ParticipantType Type { get; set; }
         public int Id { get; set; }
+
+
     }
 }

--- a/src/MercuriusAPI/DTOs/LAN/PlayerDTOs/GetPlayerDTO.cs
+++ b/src/MercuriusAPI/DTOs/LAN/PlayerDTOs/GetPlayerDTO.cs
@@ -30,6 +30,7 @@ namespace MercuriusAPI.DTOs.LAN.PlayerDTOs
             RiotId = player.RiotId;
             Email = player.Email;
             Teams = player.Teams.Select(t => new GetTeamDTO(t));
+            Type = ParticipantType.Player;
         }       
     }
 }

--- a/src/MercuriusAPI/DTOs/LAN/TeamDTOs/GetTeamDTO.cs
+++ b/src/MercuriusAPI/DTOs/LAN/TeamDTOs/GetTeamDTO.cs
@@ -17,6 +17,7 @@ namespace MercuriusAPI.DTOs.LAN.TeamDTOs
             Players = team.Players.Select(p => new GetTeamPlayerDTO(p));
             TeamInvites = team.TeamInvites.Where(i => i.Status == TeamInviteStatus.Pending).Select(i => new TeamInviteDTO(i));
             CaptainId = team.CaptainId;
+            Type = ParticipantType.Team;
         }
     }
 }

--- a/src/MercuriusAPI/Data/MercuriusDBContext.cs
+++ b/src/MercuriusAPI/Data/MercuriusDBContext.cs
@@ -50,7 +50,7 @@ namespace MercuriusAPI.Data
                 entity.HasKey(e => e.Id);
                 entity.HasOne(e => e.Participant1)
                       .WithMany()
-                      .HasForeignKey(e => e.Pariticipant1Id).IsRequired(false);
+                      .HasForeignKey(e => e.Participant1Id).IsRequired(false);
                 entity.HasOne(e => e.Participant2)
                       .WithMany()
                       .HasForeignKey(e => e.Participant2Id).IsRequired(false);

--- a/src/MercuriusAPI/Migrations/20250805094205_FixTypeInMatchParticipant1Id.Designer.cs
+++ b/src/MercuriusAPI/Migrations/20250805094205_FixTypeInMatchParticipant1Id.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MercuriusAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MercuriusAPI.Migrations
 {
     [DbContext(typeof(MercuriusDBContext))]
-    partial class MercuriusDBContextModelSnapshot : ModelSnapshot
+    [Migration("20250805094205_FixTypeInMatchParticipant1Id")]
+    partial class FixTypeInMatchParticipant1Id
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MercuriusAPI/Migrations/20250805094205_FixTypeInMatchParticipant1Id.cs
+++ b/src/MercuriusAPI/Migrations/20250805094205_FixTypeInMatchParticipant1Id.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MercuriusAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixTypeInMatchParticipant1Id : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Matches_Participants_Pariticipant1Id",
+                table: "Matches");
+
+            migrationBuilder.RenameColumn(
+                name: "Pariticipant1Id",
+                table: "Matches",
+                newName: "Participant1Id");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Matches_Pariticipant1Id",
+                table: "Matches",
+                newName: "IX_Matches_Participant1Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Matches_Participants_Participant1Id",
+                table: "Matches",
+                column: "Participant1Id",
+                principalTable: "Participants",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Matches_Participants_Participant1Id",
+                table: "Matches");
+
+            migrationBuilder.RenameColumn(
+                name: "Participant1Id",
+                table: "Matches",
+                newName: "Pariticipant1Id");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Matches_Participant1Id",
+                table: "Matches",
+                newName: "IX_Matches_Pariticipant1Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Matches_Participants_Pariticipant1Id",
+                table: "Matches",
+                column: "Pariticipant1Id",
+                principalTable: "Participants",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/src/MercuriusAPI/Models/LAN/Match.cs
+++ b/src/MercuriusAPI/Models/LAN/Match.cs
@@ -13,7 +13,7 @@
         public bool IsLowerBracketMatch { get; set; }
 
         public int GameId { get; set; }
-        public int? Pariticipant1Id { get; set; }
+        public int? Participant1Id { get; set; }
         public int? Participant2Id { get; set; }
         public int? WinnerId { get; set; }
         public int? LoserId { get; set; }

--- a/src/MercuriusAPI/Program.cs
+++ b/src/MercuriusAPI/Program.cs
@@ -35,6 +35,18 @@ namespace MercuriusAPI
                 options.EnableEndpointRouting = false;
                 options.Filters.Add<ExceptionFilter>();
             });
+
+            // Add CORS policy to allow all origins
+            builder.Services.AddCors(options =>
+            {
+                options.AddPolicy("AllowAll", builder =>
+                {
+                    builder.AllowAnyOrigin()
+                           .AllowAnyMethod()
+                           .AllowAnyHeader();
+                });
+            });
+
             var app = builder.Build();
 
             if (app.Environment.IsDevelopment())
@@ -45,8 +57,10 @@ namespace MercuriusAPI
 
             app.UseHttpsRedirection();
 
-            app.UseAuthorization();
+            // Use CORS middleware in the HTTP request pipeline
+            app.UseCors("AllowAll");
 
+            app.UseAuthorization();
 
             app.MapControllers();
 

--- a/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/DoubleEliminationMatchModerator.cs
+++ b/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/DoubleEliminationMatchModerator.cs
@@ -15,6 +15,7 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
             GenerateLowerBracketMatches(game, matches);
             GenerateGrandFinalMatch(game, matches);
             matches = AssignNextMatchesForDoubleElimination(matches).ToList();
+            matches.AssignByeWinnersNextMatch();
             return matches;
         }
         private void GenerateUpperBracketMatches(Game game, IEnumerable<Participant> participants, List<Match> matches)


### PR DESCRIPTION
### Bugfix: Double elimination bracket generation was messed up
---

### **1. What does this PR do?**

- Fixes double elimination bracket generation, winner next matches and loser next matches weren't being assigned correctly
- Fixes assigning of BYE wins in double elimination bracket
- Adds a Discriminator on the outgoing base type of ParticipantDTO (to make it easier in front-end to deserialize)

### **2. Why is this change necessary?**

Double elimination brackets were not useable.

### **3. How was it implemented? (Technical Details)**

- Fixed DoubleEliminationMatchModerator, some calculations were way off.

