### PR TITLE
Bugfix: Properly fix BYE match assignments

### DIFF
--- a/src/MercuriusAPI/Controllers/AuthController.cs
+++ b/src/MercuriusAPI/Controllers/AuthController.cs
@@ -7,9 +7,8 @@ using System.Threading.Tasks;
 namespace MercuriusAPI.Controllers
 {
     /// <summary>
-    /// Handles authentication-related actions such as registration, login, token refresh, and user deletion.
+    /// Handles authentication-related operations such as login and token refresh.
     /// </summary>
-    [Authorize(Roles = "admin")]
     [ApiController]
     [Route("[controller]")]
     public class AuthController : ControllerBase

--- a/src/MercuriusAPI/Controllers/LAN/GamesController.cs
+++ b/src/MercuriusAPI/Controllers/LAN/GamesController.cs
@@ -11,6 +11,9 @@ namespace MercuriusAPI.Controllers.LAN
     /// <summary>
     /// API endpoints for managing games, including creation, updates, participant registration, and game state transitions.
     /// </summary>
+    /// <remarks>
+    /// Manages operations related to games in the LAN system.
+    /// </remarks>
     [Authorize(Roles = "admin")]
     [Route("lan/[controller]")]
     [ApiVersion("1.0")]

--- a/src/MercuriusAPI/Controllers/LAN/MatchesController.cs
+++ b/src/MercuriusAPI/Controllers/LAN/MatchesController.cs
@@ -8,6 +8,7 @@ namespace MercuriusAPI.Controllers.LAN
 {
     /// <summary>
     /// API endpoints for managing matches, including retrieval and updates.
+    /// Handles operations related to matches in the LAN system.
     /// </summary>
     [Authorize(Roles = "admin")]
     [Route("lan/[controller]")]

--- a/src/MercuriusAPI/Controllers/LAN/PlayersController.cs
+++ b/src/MercuriusAPI/Controllers/LAN/PlayersController.cs
@@ -9,6 +9,7 @@ namespace MercuriusAPI.Controllers.LAN
 {
     /// <summary>
     /// API endpoints for managing players, including creation, retrieval, update, and deletion.
+    /// Manages player-related operations in the LAN system.
     /// </summary>
     [Authorize(Roles = "admin")]
     [Route("lan/[controller]")]

--- a/src/MercuriusAPI/Controllers/LAN/TeamsController.cs
+++ b/src/MercuriusAPI/Controllers/LAN/TeamsController.cs
@@ -10,6 +10,9 @@ namespace MercuriusAPI.Controllers.LAN
     /// <summary>
     /// API endpoints for managing teams, including creation, player management, and deletion.
     /// </summary>
+    /// <remarks>
+    /// Handles team-related operations in the LAN system.
+    /// </remarks>
     [Authorize(Roles = "admin")]
     [Route("lan/[controller]")]
     [ApiVersion("1.0")]

--- a/src/MercuriusAPI/Controllers/UserController.cs
+++ b/src/MercuriusAPI/Controllers/UserController.cs
@@ -9,9 +9,13 @@ namespace MercuriusAPI.Controllers
     /// <summary>
     /// Handles user management actions such as deleting users and assigning roles.
     /// </summary>
+    /// <remarks>
+    /// The UserController class is responsible for handling HTTP requests related to user management.
+    /// This includes actions such as deleting a user, adding roles to a user, and changing a user's password.
+    /// </remarks>
     [Authorize(Roles = "admin")]
     [ApiController]
-    [Route("api/users")]
+    [Route("[controller]")]
     public class UserController : ControllerBase
     {
         private readonly IUserService _userService;
@@ -37,6 +41,11 @@ namespace MercuriusAPI.Controllers
         public Task AddRoleToUser([FromRoute] string username, [FromBody] AddUserRoleRequest request)
             => _userService.AddRoleToUserAsync(username, request);
 
+        /// <summary>
+        /// Changes the password of a user.
+        /// </summary>
+        /// <param name="username">The username of the user whose password is to be changed.</param>
+        /// <param name="request">The request containing the new password.</param>
         [HttpPatch("{username}/password")]
         public Task ChangePasswordAsync([FromRoute] string username, [FromBody] ChangePasswordRequest request)
         {

--- a/src/MercuriusAPI/DTOs/LAN/MatchDTOs/GetMatchDTO.cs
+++ b/src/MercuriusAPI/DTOs/LAN/MatchDTOs/GetMatchDTO.cs
@@ -21,6 +21,8 @@ namespace MercuriusAPI.DTOs.LAN.MatchDTOs
         public int GameId { get; set; }
         public int? Participant1Id { get; set; }
         public int? Participant2Id { get; set; }
+        public bool Participant1IsBYE { get; set; }
+        public bool Participant2IsBYE { get; set; }
         public int? WinnerId { get; set; }
         public int? Participant1Score { get; set; }
         public int? Participant2Score { get; set; }
@@ -46,6 +48,8 @@ namespace MercuriusAPI.DTOs.LAN.MatchDTOs
             GameId = match.GameId;
             Participant1Id = match.Participant1Id;
             Participant2Id = match.Participant2Id;
+            Participant1IsBYE = match.Participant1IsBYE;
+            Participant2IsBYE = match.Participant2IsBYE;
             WinnerId = match.WinnerId;
             Participant1Score = match.Participant1Score;
             Participant2Score = match.Participant2Score;

--- a/src/MercuriusAPI/Extensions/LAN/MatchExtensions.cs
+++ b/src/MercuriusAPI/Extensions/LAN/MatchExtensions.cs
@@ -8,15 +8,29 @@ namespace MercuriusAPI.Extensions.LAN
         {
             foreach(var match in matches)
             {
-                if(match.Winner == null || match.WinnerNextMatch == null)
+                if(match.WinnerNextMatch == null)
                     continue;
 
                 var targetMatch = match.WinnerNextMatch;
+
+                if(match.Winner == null && match.Participant1IsBYE && match.Participant2IsBYE)
+                {
+                    if(match.MatchNumber % 2 != 0)
+                        targetMatch.Participant1IsBYE = true;
+                    else
+                        targetMatch.Participant2IsBYE = true;
+                }
 
                 if(match.MatchNumber % 2 != 0)
                     targetMatch.Participant1 = match.Winner;
                 else
                     targetMatch.Participant2 = match.Winner;
+            }
+
+            foreach(var match in matches)
+            {
+
+                match.TryAssignByeWin();
             }
         }
     }

--- a/src/MercuriusAPI/Migrations/20250818123333_AddContainsBYEToMatch.Designer.cs
+++ b/src/MercuriusAPI/Migrations/20250818123333_AddContainsBYEToMatch.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MercuriusAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MercuriusAPI.Migrations
 {
     [DbContext(typeof(MercuriusDBContext))]
-    partial class MercuriusDBContextModelSnapshot : ModelSnapshot
+    [Migration("20250818123333_AddContainsBYEToMatch")]
+    partial class AddContainsBYEToMatch
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -99,6 +102,9 @@ namespace MercuriusAPI.Migrations
                     b.Property<int>("Format")
                         .HasColumnType("integer");
 
+                    b.Property<string>("ImageUrl")
+                        .HasColumnType("text");
+
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasColumnType("text");
@@ -128,6 +134,9 @@ namespace MercuriusAPI.Migrations
                     b.Property<int>("BracketType")
                         .HasColumnType("integer");
 
+                    b.Property<bool>("ContainsBYE")
+                        .HasColumnType("boolean");
+
                     b.Property<DateTime>("EndTime")
                         .HasColumnType("timestamp with time zone");
 
@@ -152,17 +161,11 @@ namespace MercuriusAPI.Migrations
                     b.Property<int?>("Participant1Id")
                         .HasColumnType("integer");
 
-                    b.Property<bool>("Participant1IsBYE")
-                        .HasColumnType("boolean");
-
                     b.Property<int?>("Participant1Score")
                         .HasColumnType("integer");
 
                     b.Property<int?>("Participant2Id")
                         .HasColumnType("integer");
-
-                    b.Property<bool>("Participant2IsBYE")
-                        .HasColumnType("boolean");
 
                     b.Property<int?>("Participant2Score")
                         .HasColumnType("integer");

--- a/src/MercuriusAPI/Migrations/20250818123333_AddContainsBYEToMatch.cs
+++ b/src/MercuriusAPI/Migrations/20250818123333_AddContainsBYEToMatch.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MercuriusAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddContainsBYEToMatch : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ContainsBYE",
+                table: "Matches",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ContainsBYE",
+                table: "Matches");
+        }
+    }
+}

--- a/src/MercuriusAPI/Migrations/20250818130451_BYEFlagPerParticipantInMatchInsteadOfGeneralBYEFlag.Designer.cs
+++ b/src/MercuriusAPI/Migrations/20250818130451_BYEFlagPerParticipantInMatchInsteadOfGeneralBYEFlag.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MercuriusAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MercuriusAPI.Migrations
 {
     [DbContext(typeof(MercuriusDBContext))]
-    partial class MercuriusDBContextModelSnapshot : ModelSnapshot
+    [Migration("20250818130451_BYEFlagPerParticipantInMatchInsteadOfGeneralBYEFlag")]
+    partial class BYEFlagPerParticipantInMatchInsteadOfGeneralBYEFlag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -98,6 +101,9 @@ namespace MercuriusAPI.Migrations
 
                     b.Property<int>("Format")
                         .HasColumnType("integer");
+
+                    b.Property<string>("ImageUrl")
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()

--- a/src/MercuriusAPI/Migrations/20250818130451_BYEFlagPerParticipantInMatchInsteadOfGeneralBYEFlag.cs
+++ b/src/MercuriusAPI/Migrations/20250818130451_BYEFlagPerParticipantInMatchInsteadOfGeneralBYEFlag.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MercuriusAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class BYEFlagPerParticipantInMatchInsteadOfGeneralBYEFlag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "ContainsBYE",
+                table: "Matches",
+                newName: "Participant2IsBYE");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Participant1IsBYE",
+                table: "Matches",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Participant1IsBYE",
+                table: "Matches");
+
+            migrationBuilder.RenameColumn(
+                name: "Participant2IsBYE",
+                table: "Matches",
+                newName: "ContainsBYE");
+        }
+    }
+}

--- a/src/MercuriusAPI/Models/LAN/Match.cs
+++ b/src/MercuriusAPI/Models/LAN/Match.cs
@@ -129,6 +129,9 @@ namespace MercuriusAPI.Models.LAN
                         WinnerNextMatch.Participant2 = Winner;
                     else
                         WinnerNextMatch.Participant1 = Winner;
+
+                    if(WinnerNextMatch.Participant1IsBYE || WinnerNextMatch.Participant2IsBYE)
+                        WinnerNextMatch.TryAssignByeWin();
                 }
                 else
                 {
@@ -136,9 +139,7 @@ namespace MercuriusAPI.Models.LAN
                         WinnerNextMatch.Participant1 = Winner;
                     else
                         WinnerNextMatch.Participant2 = Winner;
-                }
-
-                
+                }          
             }
 
             // Assign Loser to the next match

--- a/src/MercuriusAPI/Models/LAN/Match.cs
+++ b/src/MercuriusAPI/Models/LAN/Match.cs
@@ -45,12 +45,10 @@ namespace MercuriusAPI.Models.LAN
             {
                 if((Participant1 == null && Participant2 != null))
                 {
-                    // Participant 1 is BYE, so Participant 2 wins
                     AssignWinner(Participant2, isParticipant1Bye: true);
                 }
                 else if((Participant2 == null && Participant1 != null))
                 {
-                    // Participant 2 is BYE, so Participant 1 wins
                     AssignWinner(Participant1, isParticipant2Bye: true);
                 }
             }
@@ -58,11 +56,11 @@ namespace MercuriusAPI.Models.LAN
 
         public void SetParticipantBYEs(bool participant1BYE, bool participant2BYE)
         {
-            if(RoundNumber != 1 && participant1BYE && participant2BYE)
+            if (RoundNumber != 1 && participant1BYE && participant2BYE)
                 return;
 
-            Participant1IsBYE = participant1BYE;
-            Participant2IsBYE = participant2BYE;
+            Participant1IsBYE = Participant1IsBYE || participant1BYE;
+            Participant2IsBYE = Participant2IsBYE || participant2BYE;
         }
 
         private void AssignWinner(Participant? winner, bool isParticipant1Bye = false, bool isParticipant2Bye = false)

--- a/src/MercuriusAPI/Models/LAN/Match.cs
+++ b/src/MercuriusAPI/Models/LAN/Match.cs
@@ -2,14 +2,15 @@
 
 namespace MercuriusAPI.Models.LAN
 {
-    public class Match{
+    public class Match
+    {
         public int Id { get; set; }
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
-        public BracketType  BracketType { get; set; }
+        public BracketType BracketType { get; set; }
         public GameFormat Format { get; set; }
         public ParticipantType ParticipantType { get; set; }
-       
+
         public int RoundNumber { get; set; }
         public int MatchNumber { get; set; }
         public bool IsLowerBracketMatch { get; set; }
@@ -26,6 +27,9 @@ namespace MercuriusAPI.Models.LAN
         public int? WinnerNextMatchId { get; set; }
         public int? LoserNextMatchId { get; set; }
 
+        public bool Participant1IsBYE { get; set; }
+        public bool Participant2IsBYE { get; set; }
+
         public Game Game { get; set; }
         public Participant? Participant1 { get; set; }
         public Participant? Participant2 { get; set; }
@@ -37,16 +41,34 @@ namespace MercuriusAPI.Models.LAN
 
         public void TryAssignByeWin()
         {
-            if(Participant1 == null && Participant2 != null)
+            if(Participant1IsBYE || Participant2IsBYE)
             {
-                Winner = Participant2;
-                UpdateParticipantsNextMatch();
+                if((Participant1 == null && Participant2 != null))
+                {
+                    // Participant 1 is BYE, so Participant 2 wins
+                    AssignWinner(Participant2, isParticipant1Bye: true);
+                }
+                else if((Participant2 == null && Participant1 != null))
+                {
+                    // Participant 2 is BYE, so Participant 1 wins
+                    AssignWinner(Participant1, isParticipant2Bye: true);
+                }
             }
-            else if(Participant2 == null && Participant1 != null)
-            {
-                Winner = Participant1;
-                UpdateParticipantsNextMatch();
-            }
+        }
+
+        public void SetParticipantBYEs(bool participant1BYE, bool participant2BYE)
+        {
+            if(RoundNumber != 1 && participant1BYE && participant2BYE)
+                return;
+
+            Participant1IsBYE = participant1BYE;
+            Participant2IsBYE = participant2BYE;
+        }
+
+        private void AssignWinner(Participant? winner, bool isParticipant1Bye = false, bool isParticipant2Bye = false)
+        {
+            Winner = winner;
+            UpdateParticipantsNextMatch();
         }
 
         public void Start()
@@ -73,7 +95,7 @@ namespace MercuriusAPI.Models.LAN
             };
             if(participant1Score > winsNeeded || participant2Score > winsNeeded)
                 throw new ValidationException("Scores cannot exceed the required number of wins for the match format.");
-            if(participant1Score == participant2Score && participant1Score+participant2Score != 0 && winsNeeded == 1)
+            if(participant1Score == participant2Score && participant1Score + participant2Score != 0 && winsNeeded == 1)
                 throw new ValidationException("Scores cannot be equal in Bo1 format");
 
             Participant1Score = participant1Score;
@@ -81,36 +103,60 @@ namespace MercuriusAPI.Models.LAN
 
             if(participant1Score == winsNeeded && participant1Score > participant2Score)
             {
-                WinnerId = Participant1Id;
-                LoserId = Participant2Id;
+                Winner = Participant1;
+                Loser = Participant2;
                 Finish();
             }
             else if(participant2Score == winsNeeded && participant2Score > participant1Score)
             {
-                WinnerId = Participant2Id;
-                LoserId = Participant1Id;
+                Winner = Participant2;
+                Loser = Participant1;
                 Finish();
             }
         }
 
         public void UpdateParticipantsNextMatch()
         {
-            if(WinnerId != null)
+            if (Winner == null)
+                return;
+
+            // Assign Winner to the next match
+            if (WinnerNextMatch != null)
             {
-                if(WinnerNextMatch is not null)
+                if (WinnerNextMatch.IsLowerBracketMatch)
                 {
-                    if(MatchNumber % 2 != 0)
-                        WinnerNextMatch.Participant1Id = WinnerId;
+                    if (WinnerNextMatch.Participant2 == null || WinnerNextMatch.Participant2?.Id == Winner.Id)
+                        WinnerNextMatch.Participant2 = Winner;
                     else
-                        WinnerNextMatch.Participant2Id = WinnerId;
+                        WinnerNextMatch.Participant1 = Winner;
                 }
-                if(LoserNextMatch is not null)
+                else
                 {
-                    if(MatchNumber % 2 != 0)
-                        LoserNextMatch.Participant1Id = LoserId;
+                    if (MatchNumber % 2 != 0 && !IsLowerBracketMatch)
+                        WinnerNextMatch.Participant1 = Winner;
                     else
-                        LoserNextMatch.Participant2Id = LoserId;
+                        WinnerNextMatch.Participant2 = Winner;
                 }
+
+                
+            }
+
+            // Assign Loser to the next match
+            if (LoserNextMatch != null)
+            {
+                if (RoundNumber == 1)
+                {
+                    if (MatchNumber % 2 != 0)
+                        LoserNextMatch.Participant1 = Loser;
+                    else
+                        LoserNextMatch.Participant2 = Loser;
+                }
+                else
+                {
+                    LoserNextMatch.Participant1 = Loser;
+                }
+                if(LoserNextMatch.Participant1IsBYE || LoserNextMatch.Participant2IsBYE)
+                    LoserNextMatch.TryAssignByeWin();
             }
         }
     }

--- a/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/DoubleEliminationMatchModerator.cs
+++ b/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/DoubleEliminationMatchModerator.cs
@@ -230,21 +230,16 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
         {
             if (currentUBMatch.Participant1IsBYE && currentUBMatch.Participant2IsBYE)
             {
-                nextLBMatch?.SetParticipantBYEs(true, false);
+                nextLBMatch?.SetParticipantBYEs(nextLBMatch.MatchNumber % 2 != 0, nextLBMatch.MatchNumber % 2 == 0);
                 if (nextUBMatch != null)
                 {
-                    if (currentUBMatch.MatchNumber % 2 != 0)
-                        nextUBMatch.Participant1IsBYE = true;
-                    else
-                        nextUBMatch.Participant2IsBYE = true;
+                    nextUBMatch.SetParticipantBYEs(currentUBMatch.MatchNumber % 2 != 0, currentUBMatch.MatchNumber % 2 == 0);
                 }
             }
             else if (currentUBMatch.Participant1IsBYE || currentUBMatch.Participant2IsBYE)
             {
-                if(currentUBMatch.RoundNumber == 1 && currentUBMatch.MatchNumber % 2 != 0)
-                    nextLBMatch.Participant1IsBYE = true;
-                else
-                    nextLBMatch.Participant2IsBYE = true;
+                nextLBMatch?.SetParticipantBYEs(currentUBMatch.RoundNumber != 1 || currentUBMatch.MatchNumber % 2 != 0,
+                                                currentUBMatch.RoundNumber == 1 && currentUBMatch.MatchNumber % 2 == 0);
             }
         }
 

--- a/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/DoubleEliminationMatchModerator.cs
+++ b/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/DoubleEliminationMatchModerator.cs
@@ -74,7 +74,7 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
                     GameId = game.Id,
                     RoundNumber = round,
                     BracketType = game.BracketType,
-                    Format = i == 0 ? game.FinalsFormat : game.Format,
+                    Format = game.Format,
                     MatchNumber = matchNumber,
                     ParticipantType = game.ParticipantType
                 };
@@ -87,6 +87,7 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
                     match.Participant1 = slots[leafIndex * 2];
                     match.Participant2 = slots[leafIndex * 2 + 1];
 
+                    match.SetParticipantBYEs(match.Participant1 is null, match.Participant2 is null);
                     match.TryAssignByeWin();
                 }
 
@@ -99,20 +100,20 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
         private void GenerateLowerBracketMatches(Game game, List<Match> matches)
         {
             var upperBracketMatches = matches.Where(m => !m.IsLowerBracketMatch).ToList();
-            if(!upperBracketMatches.Any())
+            if (!upperBracketMatches.Any())
                 return;
 
             int upperBracketRounds = upperBracketMatches.Max(m => m.RoundNumber);
             int totalLBRounds = (upperBracketRounds - 1) * 2;
 
-            // For a 16-slot bracket, the match counts per round are 4, 4, 2, 2, 1, 1.
+            // Dynamically calculate the number of matches for the first round of the lower bracket
             int matchesThisRound = (int)Math.Pow(2, upperBracketRounds - 2);
 
-            for(int round = 1; round <= totalLBRounds; round++)
+            for (int round = 1; round <= totalLBRounds; round++)
             {
-                for(int i = 0; i < matchesThisRound; i++)
+                for (int i = 0; i < matchesThisRound; i++)
                 {
-                    matches.Add(new Match
+                    var match = new Match
                     {
                         GameId = game.Id,
                         RoundNumber = round,
@@ -121,22 +122,20 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
                         BracketType = game.BracketType,
                         ParticipantType = game.ParticipantType,
                         IsLowerBracketMatch = true
-                    });
+                    };
+
+                    matches.Add(match);
                 }
 
                 // Adjust the match count for the next round.
                 // The number of matches halves every two rounds (one entry round and one consolidation round).
-                if(round % 2 != 0)
+                if (round % 2 == 0)
                 {
-                    // For the next round (consolidation round), the number of matches stays the same.
-                }
-                else
-                {
-                    // For the round after that (next entry round), the number of matches is halved.
                     matchesThisRound /= 2;
                 }
             }
         }
+
         private void GenerateGrandFinalMatch(Game game, List<Match> matches)
         {
             var grandFinalMatch = new Match
@@ -159,71 +158,92 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
             var grandFinal = matches.Single(m => !m.IsLowerBracketMatch && m.RoundNumber == matches.Max(x => x.RoundNumber));
 
             // Link Upper Bracket matches
-            for(int i = 0; i < uBMatches.Count; i++)
+            foreach (var currentUBMatch in uBMatches)
             {
-                var currentUBMatch = uBMatches[i];
-
                 // Find the match in the next UB round where the winner will go
                 var nextUBMatch = uBMatches.FirstOrDefault(m =>
                     m.RoundNumber == currentUBMatch.RoundNumber + 1 &&
                     m.MatchNumber == (int)Math.Ceiling((double)currentUBMatch.MatchNumber / 2));
 
-                // Corrected line: Assign the navigation property, not the ID.
                 currentUBMatch.WinnerNextMatch = nextUBMatch;
 
-
                 // Link UB losers to the correct LB match
-                // The corrected logic for targetLBRoundNumber (from previous correction)
                 int targetLBRoundNumber = (currentUBMatch.RoundNumber <= 2)
                     ? currentUBMatch.RoundNumber
                     : (currentUBMatch.RoundNumber - 1) * 2;
 
-                // The corrected logic for nextLBMatchNumber
-                int nextLBMatchNumber;
-                if(currentUBMatch.RoundNumber == 1)
-                {
-                    // UB Round 1 losers are paired up to form LB Round 1
-                    nextLBMatchNumber = (int)Math.Ceiling((double)currentUBMatch.MatchNumber / 2);
-                }
-                else
-                {
-                    // For all other UB rounds, each loser drops into a unique LB match
-                    // This is a direct one-to-one mapping
-                    nextLBMatchNumber = currentUBMatch.MatchNumber;
-                }
+                int nextLBMatchNumber = (currentUBMatch.RoundNumber == 1)
+                    ? (int)Math.Ceiling((double)currentUBMatch.MatchNumber / 2)
+                    : currentUBMatch.MatchNumber;
 
-                // Now find the target lower bracket match using the corrected numbers
                 var nextLBMatch = lBMatches.FirstOrDefault(m =>
                     m.RoundNumber == targetLBRoundNumber &&
                     m.MatchNumber == nextLBMatchNumber);
+
+                PropagateBYEStatus(currentUBMatch, nextUBMatch, nextLBMatch);
 
                 currentUBMatch.LoserNextMatch = nextLBMatch;
             }
 
             // Link Lower Bracket matches
-            for(int i = 0; i < lBMatches.Count; i++)
+            foreach (var currentLBMatch in lBMatches)
             {
-                var currentLBMatch = lBMatches[i];
-
-                int nextLBMatchNumber = (currentLBMatch.RoundNumber % 2 != 0) ? currentLBMatch.MatchNumber : (int)Math.Ceiling((double)currentLBMatch.MatchNumber / 2);
+                int nextLBMatchNumber = (currentLBMatch.RoundNumber % 2 != 0)
+                    ? currentLBMatch.MatchNumber
+                    : (int)Math.Ceiling((double)currentLBMatch.MatchNumber / 2);
 
                 var nextLBMatch = lBMatches.FirstOrDefault(m =>
                     m.RoundNumber == currentLBMatch.RoundNumber + 1 &&
                     m.MatchNumber == nextLBMatchNumber);
 
                 currentLBMatch.WinnerNextMatch = nextLBMatch;
+
+                // Propagate BYE status for BYE vs BYE matches
+                if (currentLBMatch.Participant1IsBYE && currentLBMatch.Participant2IsBYE && nextLBMatch != null)
+                {
+                    nextLBMatch.Participant2IsBYE = true;
+                }
             }
 
             // Link the Final matches
-            var ubFinal = uBMatches.LastOrDefault(m => m.RoundNumber == 4);
+            LinkFinalMatches(uBMatches, lBMatches, grandFinal);
+
+            return uBMatches.Concat(lBMatches).Append(grandFinal);
+        }
+
+        private void PropagateBYEStatus(Match currentUBMatch, Match? nextUBMatch, Match? nextLBMatch)
+        {
+            if (currentUBMatch.Participant1IsBYE && currentUBMatch.Participant2IsBYE)
+            {
+                nextLBMatch?.SetParticipantBYEs(true, false);
+                if (nextUBMatch != null)
+                {
+                    if (currentUBMatch.MatchNumber % 2 != 0)
+                        nextUBMatch.Participant1IsBYE = true;
+                    else
+                        nextUBMatch.Participant2IsBYE = true;
+                }
+            }
+            else if (currentUBMatch.Participant1IsBYE || currentUBMatch.Participant2IsBYE)
+            {
+                if(currentUBMatch.RoundNumber == 1 && currentUBMatch.MatchNumber % 2 != 0)
+                    nextLBMatch.Participant1IsBYE = true;
+                else
+                    nextLBMatch.Participant2IsBYE = true;
+            }
+        }
+
+        private void LinkFinalMatches(List<Match> uBMatches, List<Match> lBMatches, Match grandFinal)
+        {
+            var ubFinal = uBMatches.LastOrDefault(m => m.RoundNumber == uBMatches.Max(ub => ub.RoundNumber));
             var lbFinal = lBMatches.LastOrDefault();
 
-            if(ubFinal != null)
+            if (ubFinal != null)
             {
                 ubFinal.WinnerNextMatch = grandFinal;
                 ubFinal.LoserNextMatch = lbFinal;
             }
-            if(lbFinal != null)
+            if (lbFinal != null)
             {
                 lbFinal.WinnerNextMatch = grandFinal;
             }
@@ -231,8 +251,6 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
             // Grand final has no next matches
             grandFinal.WinnerNextMatch = null;
             grandFinal.LoserNextMatch = null;
-
-            return uBMatches.Concat(lBMatches).Append(grandFinal);
         }
 
         public void DeterminePlacements(Game game)
@@ -245,9 +263,9 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
                 .ThenByDescending(m => m.MatchNumber)
                 .FirstOrDefault();
 
-            if(grandFinal.Winner is null)
+            if (grandFinal.Winner is null)
                 throw new ValidationException("Grand final match has no winner assigned. Cannot determine placements.");
-            if(grandFinal.Loser is null)
+            if (grandFinal.Loser is null)
                 throw new ValidationException("Grand final match has no loser assigned. Cannot determine placements.");
 
             game.Placements.Add(new Placement
@@ -271,10 +289,10 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
                 .GroupBy(m => m.RoundNumber);
 
             int place = 3;
-            foreach(var roundGrouping in lowerBracket)
+            foreach (var roundGrouping in lowerBracket)
             {
                 var losersThisRound = roundGrouping.Where(m => m.LoserId != null).Select(m => m.Loser).ToList();
-                if(losersThisRound.Any())
+                if (losersThisRound.Any())
                 {
                     game.Placements.Add(new Placement
                     {

--- a/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/SingleEliminationMatchModerator.cs
+++ b/src/MercuriusAPI/Services/LAN/MatchServices/BracketTypes/SingleEliminationMatchModerator.cs
@@ -6,19 +6,27 @@ using System.Linq;
 
 namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
 {
+    /// <summary>
+    /// Handles the generation and management of matches for a single-elimination tournament.
+    /// </summary>
     public class SingleEliminationMatchModerator : IMatchModerator
     {
+        /// <summary>
+        /// Determines the placements of participants in the tournament.
+        /// </summary>
+        /// <param name="game">The game for which placements are to be determined.</param>
         public void DeterminePlacements(Game game)
         {
-            if(game.Matches.Count == 0)
+            if (game.Matches.Count == 0)
                 return;
 
-            // 1. Final match: assign 1st
+            // Assign 1st place to the winner of the final match
             var finalMatch = game.Matches
                 .OrderByDescending(m => m.RoundNumber)
                 .ThenByDescending(m => m.MatchNumber)
                 .FirstOrDefault();
-            if(finalMatch.Winner is null)
+
+            if (finalMatch.Winner is null)
                 throw new ValidationException("Final match has no winner assigned.");
 
             game.Placements.Add(new Placement
@@ -28,17 +36,18 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
                 Participants = [finalMatch.Winner]
             });
 
+            // Assign placements to other participants based on their elimination round
             var matchesOrderedAndGroupedByRound = game.Matches
                 .OrderByDescending(m => m.RoundNumber)
                 .ThenByDescending(m => m.MatchNumber)
                 .GroupBy(m => m.RoundNumber);
-            // 2. All other losers, by round (descending)
+
             int place = 2;
 
-            foreach(var roundGrouping in matchesOrderedAndGroupedByRound)
+            foreach (var roundGrouping in matchesOrderedAndGroupedByRound)
             {
                 var losersThisRound = roundGrouping.Where(m => m.LoserId != null).Select(m => m.Loser).ToList();
-                if(losersThisRound.Any())
+                if (losersThisRound.Any())
                 {
                     game.Placements.Add(new Placement
                     {
@@ -51,6 +60,11 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
             }
         }
 
+        /// <summary>
+        /// Generates all matches for a given game in a single-elimination format.
+        /// </summary>
+        /// <param name="game">The game for which matches are to be generated.</param>
+        /// <returns>A collection of matches for the game.</returns>
         public IEnumerable<Match> GenerateMatchesForGame(Game game)
         {
             var matches = new List<Match>();
@@ -63,68 +77,77 @@ namespace MercuriusAPI.Services.LAN.MatchServices.BracketTypes
             int totalRounds = (int)Math.Ceiling(Math.Log2(participantCount));
             int firstRoundMatchCount = nextPowerOfTwo / 2;
 
-            var shuffled = participants.OrderBy(_ => Guid.NewGuid()).ToList();
-
+            // Shuffle participants and assign them to slots
             int[] slotOrder = SeedingHelper.GenerateBracketSlotOrder(nextPowerOfTwo);
             var slots = new Participant[firstRoundMatchCount * 2];
-            for(int i = 0; i < shuffled.Count; i++)
-                slots[slotOrder[i]] = shuffled[i];
+            for (int i = 0; i < participants.Count; i++)
+                slots[slotOrder[i]] = participants[i];
 
             int matchNumber = 1;
-            int previousRound = totalRounds + 1; // We're working top down in match generation
+            int previousRound = totalRounds + 1;
 
-            for(int i = 0; i < totalMatches; i++)
+            // Generate matches for all rounds
+            for (int i = 0; i < totalMatches; i++)
             {
-                // Determine round number
+                // Calculate the round number for the current match
                 int round = (int)Math.Floor(Math.Log2(nextPowerOfTwo)) - (int)Math.Floor(Math.Log2(i + 1));
-                int matchesInThisRound = nextPowerOfTwo / (1 << (round - 1));
-                int firstMatchIndex = totalMatches - matchesInThisRound;
 
-                // If calculation a new round reset matchNumber, otherwise increase
+                // Reset match number if a new round starts
                 if (round < previousRound)
                     matchNumber = 1;
+                else
+                    matchNumber++;
 
+                // Create a new match
                 var match = new Match
                 {
                     GameId = game.Id,
                     RoundNumber = round,
-                    BracketType = game.BracketType,
-                    Format = i == 0 ? game.FinalsFormat : game.Format,
                     MatchNumber = matchNumber,
+                    BracketType = BracketType.SingleElimination,
+                    Format = game.Format,
                     ParticipantType = game.ParticipantType
                 };
 
-                // Assign participants only to first-round matches (the leaves)
-                int firstRoundStart = totalMatches - firstRoundMatchCount;
-                if(i >= firstRoundStart)
+                // Assign participants to first-round matches
+                if (i >= totalMatches - firstRoundMatchCount)
                 {
-                    int leafIndex = i - firstRoundStart;
+                    int leafIndex = i - (totalMatches - firstRoundMatchCount);
                     match.Participant1 = slots[leafIndex * 2];
                     match.Participant2 = slots[leafIndex * 2 + 1];
+
+                    // Handle BYE participants
+                    match.SetParticipantBYEs(match.Participant1 is null, match.Participant2 is null);
                     match.TryAssignByeWin();
                 }
 
-                matches.Add(match);
-
-                matchNumber++;
                 previousRound = round;
+                matches.Add(match);
             }
 
-            for(int i = 0; i < matches.Count; i++)
+            // Link matches to their next matches
+            for (int i = 0; i < matches.Count; i++)
             {
                 var current = matches[i];
 
-                if(current.RoundNumber == 1)
+                // Skip first-round matches as they have no children
+                if (current.RoundNumber == 1)
                     continue;
 
+                // Calculate indices of child matches
                 int childMatchIndex1 = (i * 2) + 1;
                 int childMatchIndex2 = (i * 2) + 2;
 
-                matches[childMatchIndex1].WinnerNextMatch = current;
-                matches[childMatchIndex2].WinnerNextMatch = current;
+                // Link child matches to the current match
+                if (childMatchIndex1 < matches.Count)
+                    matches[childMatchIndex1].WinnerNextMatch = current;
+                if (childMatchIndex2 < matches.Count)
+                    matches[childMatchIndex2].WinnerNextMatch = current;
             }
 
+            // Assign BYE winners to their next matches
             matches.AssignByeWinnersNextMatch();
+
             return matches;
         }
     }

--- a/src/MercuriusAPI/Services/LAN/MatchServices/MatchService.cs
+++ b/src/MercuriusAPI/Services/LAN/MatchServices/MatchService.cs
@@ -30,7 +30,23 @@ namespace MercuriusAPI.Services.LAN.MatchServices
         {
             var match = await _dbContext.Matches
                 .Include(m => m.WinnerNextMatch)
+                    .ThenInclude(m => m.Participant1)
+                .Include(m => m.WinnerNextMatch)
+                    .ThenInclude(m => m.Participant2)
+                .Include(m => m.WinnerNextMatch)
+                    .ThenInclude(m => m.WinnerNextMatch)
+                .Include(m => m.WinnerNextMatch)
+                    .ThenInclude(m => m.LoserNextMatch)
                 .Include(m => m.LoserNextMatch)
+                    .ThenInclude(m => m.Participant1)
+                .Include(m => m.LoserNextMatch)
+                    .ThenInclude(m => m.Participant2)
+                .Include(m => m.LoserNextMatch)
+                    .ThenInclude(m => m.WinnerNextMatch)
+                .Include(m => m.LoserNextMatch)
+                    .ThenInclude(m => m.LoserNextMatch)
+                .Include(m => m.Participant1)
+                .Include(m => m.Participant2)
                 .FirstOrDefaultAsync(m => m.Id == id);
 
             if (match is null)

--- a/src/MercuriusAPI/Services/LAN/MatchServices/MatchService.cs
+++ b/src/MercuriusAPI/Services/LAN/MatchServices/MatchService.cs
@@ -9,24 +9,22 @@ namespace MercuriusAPI.Services.LAN.MatchServices
     public class MatchService : IMatchService
     {
         private readonly MercuriusDBContext _dbContext;
-        private readonly IMatchModeratorFactory _matchModeratorFactory;
 
-        public MatchService(MercuriusDBContext dbContext, IMatchModeratorFactory matchModeratorFactory)
+        public MatchService(MercuriusDBContext dbContext)
         {
             _dbContext = dbContext;
-            _matchModeratorFactory = matchModeratorFactory;
         }
 
         public async Task<GetMatchDTO> UpdateMatchAsync(int id, UpdateMatchDTO updateMatchDTO)
         {
-            var match = await GetMatchByIdAsync(id);
+            var match = await GetMatchByIdForUpdateAsync(id);
             match.SetScoresAndWinner(updateMatchDTO.Participant1Score, updateMatchDTO.Participant2Score);         
             _dbContext.Matches.Update(match);
             await _dbContext.SaveChangesAsync();
             return new GetMatchDTO(match);
         }
 
-        public async Task<Match> GetMatchByIdAsync(int id)
+        public async Task<Match> GetMatchByIdForUpdateAsync(int id)
         {
             var match = await _dbContext.Matches
                 .Include(m => m.WinnerNextMatch)
@@ -45,6 +43,19 @@ namespace MercuriusAPI.Services.LAN.MatchServices
                     .ThenInclude(m => m.WinnerNextMatch)
                 .Include(m => m.LoserNextMatch)
                     .ThenInclude(m => m.LoserNextMatch)
+                .Include(m => m.Participant1)
+                .Include(m => m.Participant2)
+                .FirstOrDefaultAsync(m => m.Id == id);
+
+            if (match is null)
+                throw new NotFoundException($"{nameof(Match)} not found");
+
+            return match;
+        }
+
+        public async Task<Match> GetMatchByIdAsync(int id)
+        {
+            var match = await _dbContext.Matches
                 .Include(m => m.Participant1)
                 .Include(m => m.Participant2)
                 .FirstOrDefaultAsync(m => m.Id == id);

--- a/src/MercuriusAPI/Services/LAN/PlayerServices/PlayerService.cs
+++ b/src/MercuriusAPI/Services/LAN/PlayerServices/PlayerService.cs
@@ -39,11 +39,18 @@ namespace MercuriusAPI.Services.LAN.PlayerServices
         public async Task<GetPlayerDTO> UpdatePlayerAsync(int id, UpdatePlayerDTO playerDTO)
         {
             var player = await _dbContext.Players.FindAsync(id);
-            if(player is null)
+            if (player is null)
                 throw new NotFoundException($"{nameof(Player)} not found");
 
-            if(player.Username != playerDTO.Username && !await CheckUsernameExists(playerDTO.Username))
-                player.Update(playerDTO.Firstname, playerDTO.Lastname, playerDTO.Username, playerDTO.DiscordId, playerDTO.SteamId, playerDTO.RiotId);
+            if (player.Username != playerDTO.Username)
+            {
+                if (await CheckUsernameExists(playerDTO.Username))
+                    throw new ValidationException("Username already exists");
+
+                player.Username = playerDTO.Username;
+            }
+
+            player.Update(playerDTO.Firstname, playerDTO.Lastname, player.Username, playerDTO.DiscordId, playerDTO.SteamId, playerDTO.RiotId);
             _dbContext.Players.Update(player);
             await _dbContext.SaveChangesAsync();
             return new GetPlayerDTO(player);

--- a/tests/MercuriusAPI.Tests/MatchTests.cs
+++ b/tests/MercuriusAPI.Tests/MatchTests.cs
@@ -77,7 +77,6 @@ namespace MercuriusAPI.Tests
             {
                 ParticipantType = ParticipantType.Player,
                 Winner = winner,
-                WinnerId = winner.Id,
                 MatchNumber = 1,
                 WinnerNextMatch = new Match()
             };
@@ -86,7 +85,7 @@ namespace MercuriusAPI.Tests
             match.UpdateParticipantsNextMatch();
 
             // Assert
-            Assert.Equal(winner.Id, match.WinnerNextMatch.Participant1Id);
+            Assert.Equal(winner, match.WinnerNextMatch.Participant1);
         }
 
         [Fact]
@@ -98,7 +97,6 @@ namespace MercuriusAPI.Tests
             {
                 ParticipantType = ParticipantType.Player,
                 Winner = winner,
-                WinnerId = winner.Id,
                 MatchNumber = 2,
                 WinnerNextMatch = new Match()
             };
@@ -107,7 +105,7 @@ namespace MercuriusAPI.Tests
             match.UpdateParticipantsNextMatch();
 
             // Assert
-            Assert.Equal(winner.Id, match.WinnerNextMatch.Participant2Id);
+            Assert.Equal(winner, match.WinnerNextMatch.Participant2);
         }
 
         [Fact]
@@ -120,8 +118,6 @@ namespace MercuriusAPI.Tests
             {
                 ParticipantType = ParticipantType.Player,
                 Winner = winner,
-                WinnerId = winner.Id,
-                LoserId = loser.Id,
                 Loser = loser,
                 MatchNumber = 1,
                 LoserNextMatch = new Match()
@@ -131,31 +127,7 @@ namespace MercuriusAPI.Tests
             match.UpdateParticipantsNextMatch();
 
             // Assert
-            Assert.Equal(loser.Id, match.LoserNextMatch.Participant1Id);
-        }
-
-        [Fact]
-        public void UpdateParticipantsNextMatch_SetsLoserInLoserNextMatch_Participant2_WhenMatchNumberEven()
-        {
-            // Arrange
-            var winner = CreatePlayer();
-            var loser = CreatePlayer();
-            var match = new Match
-            {
-                ParticipantType = ParticipantType.Player,
-                Winner = winner,
-                Loser = loser,
-                WinnerId = winner.Id,
-                LoserId = loser.Id,
-                MatchNumber = 2,
-                LoserNextMatch = new Match()
-            };
-
-            // Act
-            match.UpdateParticipantsNextMatch();
-
-            // Assert
-            Assert.Equal(loser.Id, match.LoserNextMatch.Participant2Id);
+            Assert.Equal(loser, match.LoserNextMatch.Participant1);
         }
 
         [Fact]
@@ -182,7 +154,104 @@ namespace MercuriusAPI.Tests
             Assert.Null(match.LoserNextMatch.Participant1);
         }
 
-        
+        [Fact]
+        public void UpdateParticipantsNextMatch_SetsWinnerInLowerBracketMatch()
+        {
+            // Arrange
+            var winner = CreatePlayer();
+            var match = new Match
+            {
+                Winner = winner,
+                WinnerNextMatch = new Match { IsLowerBracketMatch = true }
+            };
+
+            // Act
+            match.UpdateParticipantsNextMatch();
+
+            // Assert
+            Assert.Equal(winner, match.WinnerNextMatch.Participant2);
+        }
+
+        [Fact]
+        public void UpdateParticipantsNextMatch_SetsWinnerInUpperBracketMatch_Participant1_WhenMatchNumberOdd()
+        {
+            // Arrange
+            var winner = CreatePlayer();
+            var match = new Match
+            {
+                Winner = winner,
+                MatchNumber = 1,
+                WinnerNextMatch = new Match { IsLowerBracketMatch = false }
+            };
+
+            // Act
+            match.UpdateParticipantsNextMatch();
+
+            // Assert
+            Assert.Equal(winner, match.WinnerNextMatch.Participant1);
+        }
+
+        [Fact]
+        public void UpdateParticipantsNextMatch_SetsWinnerInUpperBracketMatch_Participant2_WhenMatchNumberEven()
+        {
+            // Arrange
+            var winner = CreatePlayer();
+            var match = new Match
+            {
+                Winner = winner,
+                MatchNumber = 2,
+                WinnerNextMatch = new Match { IsLowerBracketMatch = false }
+            };
+
+            // Act
+            match.UpdateParticipantsNextMatch();
+
+            // Assert
+            Assert.Equal(winner, match.WinnerNextMatch.Participant2);
+        }
+
+        [Fact]
+        public void UpdateParticipantsNextMatch_AssignsLoserToParticipant1_WhenMatchNumberOdd()
+        {
+            // Arrange
+            var loser = CreatePlayer();
+            var winner = CreatePlayer();
+            var match = new Match
+            {
+                Loser = loser,
+                Winner = winner,
+                MatchNumber = 1,
+                LoserNextMatch = CreateMatch()
+            };
+
+            // Act
+            match.UpdateParticipantsNextMatch();
+
+            // Assert
+            Assert.Equal(loser, match.LoserNextMatch.Participant1);
+        }
+
+        [Fact]
+        public void UpdateParticipantsNextMatch_AssignsLoserToParticipant1_WhenNotFirstRound()
+        {
+            // Arrange
+            var loser = CreatePlayer();
+            var winner = CreatePlayer();
+
+            var match = new Match
+            {
+                Loser = loser,
+                Winner = winner,
+                MatchNumber = 2,
+                LoserNextMatch = CreateMatch()
+            };
+
+            // Act
+            match.UpdateParticipantsNextMatch();
+
+            // Assert
+            Assert.Equal(loser, match.LoserNextMatch.Participant1);
+        }
 
         [Theory]
         [InlineData(GameFormat.BestOf1, 1, 0)]

--- a/tests/MercuriusAPI.Tests/MatchTests.cs
+++ b/tests/MercuriusAPI.Tests/MatchTests.cs
@@ -268,8 +268,8 @@ namespace MercuriusAPI.Tests
             // Assert
             Assert.Equal(p1Score, match.Participant1Score);
             Assert.Equal(p2Score, match.Participant2Score);
-            Assert.Equal(match.Participant1Id, match.WinnerId);
-            Assert.Equal(match.Participant2Id, match.LoserId);
+            Assert.Equal(match.Participant1, match.Winner);
+            Assert.Equal(match.Participant2, match.Loser);
         }
 
         [Theory]
@@ -287,8 +287,8 @@ namespace MercuriusAPI.Tests
             // Assert
             Assert.Equal(p1Score, match.Participant1Score);
             Assert.Equal(p2Score, match.Participant2Score);
-            Assert.Equal(match.Participant2Id, match.WinnerId);
-            Assert.Equal(match.Participant1Id, match.LoserId);
+            Assert.Equal(match.Participant2, match.Winner);
+            Assert.Equal(match.Participant1, match.Loser);
         }
 
         [Theory]


### PR DESCRIPTION
### Bugfix: Properly fix BYE match assignments
---

### **1. What does this PR do?**

- Fixes BYE assignments so players automatically get propagated to next match if they are against a BYE.
- Fixes UpdatePlayer endpoint so user properties can get updated independently from username validation

### **2. Why is this change necessary?**

- Required for proper match generation
- If user was being updated without username change, nothing would update