### PR TITLE
cicd: Add secrets as environment variables in container image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,4 +67,9 @@ jobs:
             --registry ${{ vars.CONTAINER_REGISTRY }} \
             --image $IMAGE \
             --file ${{ env.DOCKERFILE_PATH }} \
+            --build-arg InitialUser__Password="${{ secrets.API_INITIALUSER_PASSWORD }}" \
+            --build-arg InitialUser__Role="${{ secrets.API_INITIALUSER_ROLE }}" \
+            --build-arg InitialUser__Username="${{ secrets.API_INITIALUSER_USERNAME }}" \
+            --build-arg Jwt__Key="${{ secrets.API_JWT_KEY }}" \
+            --build-arg ConnectionStrings__MercuriusDB="${{ secrets.API_CONNECTIONSTRINGS_MERCURIUSDB }}" \
             ${{ env.CONTEXT_PATH }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0 AS build
 
 # Arguments
 ARG BUILD_CONFIGURATION=Release
+ARG InitialUser__Password
+ARG InitialUser__Role
+ARG InitialUser__Username
+ARG Jwt__Key
+ARG ConnectionStrings__MercuriusDB
 
 # Workdir
 WORKDIR /src
@@ -29,4 +34,9 @@ RUN dotnet publish \
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless AS run
 WORKDIR /app
 COPY --from=build /app/publish .
+ENV InitialUser__Password=${InitialUser__Password}
+ENV InitialUser__Role=${InitialUser__Role}
+ENV InitialUser__Username=${InitialUser__Username}
+ENV Jwt__Key=${Jwt__Key}
+ENV ConnectionStrings__MercuriusDB=${ConnectionStrings__MercuriusDB}
 ENTRYPOINT ["dotnet", "MercuriusAPI.dll"]


### PR DESCRIPTION
### cicd: Add secrets as environment variables in container image
---
Closes #37

### **1. What does this PR do?**

- Configures environment variables in the docker container


### **2. Why is this change necessary?**

These env. variables are required for proper functioning of the API.

### **3. How was it implemented? (Technical Details)**

- cd pipeline passes secrets as args to docker file => docker file sets ENV