### PR TITLE
ci: replace Azure steps with Docker Hub

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ name: Continuous Delivery
 on:
   push:
     branches:
-    - main
+      - main
 
 env:
   IMAGE_NAME: backend
@@ -16,14 +16,14 @@ permissions:
   contents: write
   pull-requests: write
 
-jobs:      
+jobs:
   release-please:
     runs-on: ubuntu-24.04
     name: Calculate SemVersion and Create Release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Release Please
         uses: googleapis/release-please-action@v4
         id: release
@@ -47,24 +47,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Log into Azure
-        uses: azure/login@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and Push image
-        if: ${{ needs.release-please.outputs.RELEASE_CREATED }}
-        run: |
-          IMAGE="${{ vars.CONTAINER_REGISTRY }}.azurecr.io/${{ env.IMAGE_NAME }}:${{ needs.release-please.outputs.VERSION }}"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-          az acr login \
-            --name ${{ vars.CONTAINER_REGISTRY }} \
-            --expose-token
-
-          az acr build \
-            --registry ${{ vars.CONTAINER_REGISTRY }} \
-            --image $IMAGE \
-            --file ${{ env.DOCKERFILE_PATH }} \
-            ${{ env.CONTEXT_PATH }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: livingwooods/mercurius-backend:${{ needs.release-please.outputs.VERSION }}


### PR DESCRIPTION
This pull request updates the continuous deployment workflow to use Docker Hub for image building and publishing, replacing the previous Azure Container Registry setup. The workflow now leverages official Docker GitHub Actions for authentication, building, and pushing images, streamlining the deployment process.

**Deployment workflow migration:**

* Replaced Azure login with Docker Hub authentication using the `docker/login-action@v3` and relevant Docker Hub credentials.
* Removed Azure Container Registry build and push steps, transitioning to Docker's Buildx and Build-Push actions for image building and publishing.
* Added setup for Docker Buildx with `docker/setup-buildx-action@v3` to enable advanced Docker build capabilities.
* Updated image publishing to use `docker/build-push-action@v6`, pushing images directly to Docker Hub under the `livingwooods/mercurius-backend` repository with the release version tag.