### PR TITLE
Add unified Phase implementation plans for Issues #47 and #50

### DIFF
--- a/docs/issue-47-50-phase-implementation-plan.md
+++ b/docs/issue-47-50-phase-implementation-plan.md
@@ -1,0 +1,181 @@
+# Issue #47 + #50 — Detailed Phase Implementation Plan
+
+This document expands the unified strategy into concrete, execution-ready phase plans.
+
+## Scope baseline
+- Issue #47: unify players/users, remove `Player` and `Participant`, and move to explicit team/individual game-match modeling.
+- Issue #50: simplify `Game`/`Match` coupling and enforce deletion-safe relationship behavior.
+
+---
+
+## Phase 0 — Discovery and failure reproduction
+
+### Objective
+Create a complete map of coupling points and lock in current failures with tests.
+
+### Deliverables
+1. **Coupling matrix document** (`docs/internal/relation-matrix.md`)
+   - Entity-to-entity ownership and cardinality
+   - Current delete behaviors
+   - Service-layer deep traversal hotspots
+2. **Failing regression tests** for current breakage scenarios
+   - User/player deletion impacting game/match/team reads
+   - Participant-dependent logic assumptions in match generation/read
+3. **Refactor impact list**
+   - Ranked by risk (high/medium/low)
+
+### Implementation tasks
+- Enumerate model and DB-context relations.
+- Enumerate every service/controller path that reads `Player`/`Participant`.
+- Add targeted tests that demonstrate current undesired outcomes.
+
+### Exit criteria
+- Coupling matrix reviewed and complete.
+- At least one failing test per known failure class is present.
+- Refactor hotspots prioritized.
+
+---
+
+## Phase 1 — Compatibility layer (bridge release)
+
+### Objective
+Introduce user-centric abstraction so downstream code can migrate incrementally.
+
+### Deliverables
+1. `ICompetitionIdentityResolver` (or equivalent) abstraction.
+2. Adapter implementation that resolves identity via legacy player/user paths.
+3. Service-level usage of resolver in high-traffic game/match flows.
+
+### Implementation tasks
+- Add resolver abstraction and default implementation.
+- Refactor selected services to use resolver instead of direct `Player` assumptions.
+- Add unit tests for resolver behavior (legacy + user-centric paths).
+
+### Exit criteria
+- Critical flows no longer directly depend on `Player` lookups.
+- All new resolver tests pass.
+- No API contract changes yet.
+
+---
+
+## Phase 2 — Data model transition (#47 core)
+
+### Objective
+Move schema/data toward user-first model and remove participant-centric storage.
+
+### Deliverables
+1. **Migration A: user profile consolidation**
+   - Move required player data to user-owned structure.
+2. **Migration B: team-user relation**
+   - Introduce/upgrade join relation from team→user.
+3. **Migration C: participant removal path**
+   - Replace participant references with typed game/match ownership fields.
+4. **Data backfill script**
+   - Deterministic mapping and idempotent execution support.
+
+### Implementation tasks
+- Author additive migrations first (non-destructive).
+- Backfill data and validate row counts/integrity constraints.
+- Introduce deprecation markers on old columns/tables.
+
+### Exit criteria
+- All required player data is available through user-owned model.
+- Team membership works with user references.
+- Participant-dependent schema paths are deprecated and no longer required by new writes.
+
+---
+
+## Phase 3 — Domain/service refactor (#47 + #50 joint)
+
+### Objective
+Switch business logic to explicit team-vs-individual models and remove participant/player runtime dependency.
+
+### Deliverables
+1. Typed game/match handling strategy
+   - `TeamGame` / `IndividualGame` handling path
+   - `TeamMatch` / `IndividualMatch` handling path
+2. Updated service orchestration for create/read/update flows.
+3. Unified error-handling policy for missing/deactivated users.
+
+### Implementation tasks
+- Replace participant traversal branches with typed strategy resolution.
+- Replace player-centric DTO mapping with user-centric mapping.
+- Remove null-fragile relation walks in game/match services.
+
+### Exit criteria
+- Active flows do not require `Player` or `Participant`.
+- Team and individual modes are both supported in tests.
+- API responses remain deterministic for missing-linked-user scenarios.
+
+---
+
+## Phase 4 — Deletion semantics hardening (#50 core)
+
+### Objective
+Guarantee user deletion/deactivation safety across historical competition data.
+
+### Deliverables
+1. EF relationship rules updated for safe delete behavior.
+2. Deletion workflow in service layer (detach/reassign/archive semantics).
+3. Integration tests for delete-then-read/update across aggregates.
+
+### Implementation tasks
+- Replace unsafe cascades with `Restrict`/`SetNull` where appropriate.
+- Implement guarded delete/deactivate command path.
+- Add end-to-end tests against game/match/team endpoints.
+
+### Exit criteria
+- Deleting/deactivating a user does not break historical data retrieval.
+- No referential-integrity exceptions in supported delete flows.
+- Regression suite for deletion scenarios is green.
+
+---
+
+## Phase 5 — Legacy removal and cleanup
+
+### Objective
+Finalize migration by removing deprecated models, schema artifacts, and bridge code.
+
+### Deliverables
+1. Remove `Player` and `Participant` domain artifacts.
+2. Drop deprecated DB columns/tables after verification window.
+3. Remove compatibility resolver fallback logic no longer needed.
+4. Update docs/changelog/swagger notes for finalized model.
+
+### Implementation tasks
+- Delete dead code and obsolete mappings.
+- Run full regression suite and migration upgrade-from-snapshot tests.
+- Validate no lingering compile/runtime references.
+
+### Exit criteria
+- Codebase compiles and tests pass without legacy entities.
+- Schema is clean of deprecated artifacts.
+- Documentation reflects final domain model.
+
+---
+
+## Cross-phase governance
+
+### Required checkpoints (end of each phase)
+- Architecture review sign-off
+- Migration safety review (if schema touched)
+- Test coverage delta review
+- Rollback/readiness note
+
+### Rollout strategy
+- Prefer multiple small PRs per phase over one large PR.
+- Keep migration PRs isolated from large service refactors when possible.
+- Ship compatibility bridges before destructive schema removals.
+
+### Suggested PR sequence
+1. Phase 0 tests + relation matrix
+2. Phase 1 compatibility abstraction
+3. Phase 2 migrations/backfill
+4. Phase 3 service/domain refactor
+5. Phase 4 delete hardening
+6. Phase 5 cleanup/removals
+
+## Definition of done (program level)
+- Issue #47 acceptance: no first-class `Player`/`Participant` dependency in active flows.
+- Issue #50 acceptance: deletion-safe, simplified `Game`/`Match` relation behavior with stable APIs.
+- Operational acceptance: upgrade + rollback paths validated on seeded snapshots.

--- a/docs/issue-50-plan.md
+++ b/docs/issue-50-plan.md
@@ -1,97 +1,96 @@
-# Issue #50 Plan — Code simplification
+# Issue #47 + #50 Unified Implementation Plan — Player/User unification and relation simplification
 
-## Issue context
-Issue #50 (opened April 28, 2026) asks to simplify the codebase, with focus on **Game** and **Match** structures. It specifically requests minimizing hard references/relations and ensuring that deleting one user/player does not break connected matches/games/teams.
+## Source issues
+- **Issue #47: "Unification of players and users"** (opened **April 28, 2026**).
+  - `Player` should no longer be a separate entity.
+  - `Participant` should be removed.
+  - Player attributes (email, socials) should belong to `User`.
+  - Teams should contain `User` references, not players.
+  - On `Game` and `Match` levels, replace participant-based modeling with specialized forms for team-vs-individual logic.
+- **Issue #50: "Code simplification"** (opened **April 28, 2026**).
+  - Simplify `Game`/`Match` relations and reduce fragile hard references.
+  - Ensure user deletion does not break related game/match/team data.
 
-## Goals
-- Reduce tight coupling between `Game`, `Match`, `Team`, `Participant`, and `Player`.
-- Prevent entity deletions from causing cascading breakage or invalid object graphs.
-- Keep current API behavior stable where possible while making relation handling safer.
+## Why these must be implemented together
+Issue #47 changes core domain shape (`Player`/`Participant` removal), while issue #50 changes relation safety and traversal strategy. Implementing one without the other would likely create duplicate migrations, incompatible service assumptions, and temporary API instability.
 
-## Non-goals
-- Full domain rewrite.
-- Changing bracket business logic behavior unless required by decoupling.
-- Introducing breaking API changes without migration/compatibility path.
+## Target domain model (combined end state)
 
-## Proposed approach
+### Entity-level changes
+1. **Remove `Player` as first-class domain entity**.
+   - Migrate required player profile fields into `User` (or linked user-profile value object/table).
+2. **Remove `Participant` entity**.
+   - Replace with explicit game/match polymorphism:
+     - `TeamGame` and `IndividualGame` (derived/specialized representations)
+     - `TeamMatch` and `IndividualMatch` (or equivalent typed strategy)
+3. **Team membership points to `User`**.
+   - Team-user link table/relation replaces team-player relation.
 
-### 1) Baseline mapping of current coupling
-- Inventory all direct entity references and navigation chains in:
-  - `Models/*` (especially `Game`, `Match`, `Participant`, `Team`, `Player`)
-  - `MercuriusDBContext` relationship configuration
-  - Services that eagerly traverse those relations
-- Create a quick dependency matrix: **who owns who**, **who can be null**, **what deletes cascade**.
+### Relation-safety changes
+1. Convert risky delete cascades from user links to safer behaviors (`Restrict`/`SetNull` where history is required).
+2. Preserve historical competition records even after a user deletion/deactivation.
+3. Replace deep navigation assumptions with explicit ID-based loading and guarded mapping.
 
-### 2) Define safe ownership boundaries
-- Treat `Game` and `Match` as aggregate roots with stable identifiers.
-- Replace hard object dependencies where possible with ID-based references and guarded lookups at service boundaries.
-- Introduce explicit "inactive/orphan-safe" behavior for removed users/players (e.g., soft deletion marker or placeholder participant semantics).
+## Implementation plan
 
-### 3) Refactor deletion semantics
-- Update EF Core relationship rules to avoid dangerous cascade paths:
-  - Prefer `Restrict`/`SetNull` for user/player links that should not destroy historical match/game records.
-- Add service-layer guard rails:
-  - Deleting a player/user should trigger controlled detachment/reassignment workflow.
-  - Ensure teams/matches/games remain queryable and valid post-delete.
+### Phase 0 — Discovery and safety net
+- Map current dependencies across:
+  - `Models/*` (especially `Game`, `Match`, `Participant`, `Team`, `Player`, `User`)
+  - DB context relationship configuration
+  - Services/controllers assuming `Player`/`Participant`
+- Add failing tests that reproduce:
+  - user/player delete breakages
+  - participant-dependent flows in game/match generation/read paths
 
-### 4) Simplify service logic around Game/Match
-- Move relation resolution into clearly scoped helper methods.
-- Remove implicit assumptions that every participant always maps to an active player record.
-- Normalize error handling for missing related entities (consistent `NotFound`/validation behavior).
+### Phase 1 — Introduce compatibility layer
+- Add transitional mapping so services can resolve user-centric identity while legacy entities still exist.
+- Add adapter/helpers that encapsulate "current player source" to limit touching all call-sites at once.
 
-### 5) API contract hardening
-- Ensure endpoint responses remain stable even when related user/player is missing.
-- Return deterministic fallback payload values instead of null-reference failures.
-- Document any response-shape changes in Swagger annotations/changelog if unavoidable.
+### Phase 2 — Data model transition (#47 core)
+- Migration set A:
+  - copy/merge required player attributes into user-owned structure
+  - create/upgrade team-user link
+- Migration set B:
+  - remove participant links in favor of typed game/match relations
+- Keep reversible migration path with explicit rollback notes.
 
-## Work breakdown
-1. **Discovery PR**
-   - Add tests that reproduce current failure modes when deleting linked player/user.
-   - Add relationship matrix notes (internal doc/comment).
-2. **Data-model PR**
-   - Adjust EF relationships and migration(s).
-   - Implement deletion-safe entity configuration.
-3. **Service-layer PR**
-   - Refactor Game/Match flows to use safe lookup patterns and defensive mapping.
-4. **Endpoint stabilization PR**
-   - Ensure outward API behavior consistency and update docs.
-5. **Cleanup PR**
-   - Remove dead code, simplify duplicated relation traversal, finalize naming.
+### Phase 3 — Service refactor (#47 + #50 joint)
+- Replace participant traversal with typed game/match resolution paths.
+- Replace player-centric service logic with user-centric logic.
+- Normalize not-found/inactive-user behavior so responses are deterministic.
 
-## Testing plan
-- Unit tests:
-  - Delete player/user linked to team/match/game should not break retrieval or updates.
-  - Match generation/update still functions with inactive/missing linked player.
-- Integration tests:
-  - End-to-end delete scenario followed by reads on game, match, team endpoints.
-  - Regression tests for bracket flows.
-- Migration validation:
-  - Apply migration on existing dev DB snapshot and verify no destructive data loss.
+### Phase 4 — Deletion semantics hardening (#50 core)
+- Enforce deletion workflows that detach/reassign links instead of breaking aggregates.
+- Ensure read endpoints for game/match/team still return stable payloads after user deletion/deactivation.
+
+### Phase 5 — Remove legacy artifacts
+- Drop obsolete `Player` and `Participant` code paths and schema remnants.
+- Remove temporary compatibility helpers.
+- Final cleanup for duplicate traversal and naming.
+
+## Test plan
+- **Unit tests**
+  - Team membership and game/match creation using `User` only.
+  - Individual and team game/match flows without participant entity.
+  - Deleting/deactivating user preserves historical game/match/team integrity.
+- **Integration tests**
+  - Full flow: create users/teams/games/matches → delete/deactivate user → re-read/update dependent resources.
+  - Regression tests for bracket and result update flows.
+- **Migration tests**
+  - Upgrade from pre-#47 schema snapshot and verify data preservation.
+  - Verify rollback path in non-production DB.
 
 ## Acceptance criteria
-- Deleting a user/player does not break reads or writes for related matches/games/teams.
-- Game/Match service code has reduced direct relation traversal and fewer hard object dependencies.
-- Tests cover deletion safety scenarios and pass in CI.
-- No unintended breaking API changes; any required changes are documented.
-
-## Risks and mitigations
-- **Risk:** Hidden assumptions in bracket/moderator logic.
-  - **Mitigation:** Add focused regression tests per bracket type before refactor.
-- **Risk:** Migration side effects on existing relation constraints.
-  - **Mitigation:** Validate migration on seeded data and document rollback steps.
-- **Risk:** Performance impact from replacing navigations with lookups.
-  - **Mitigation:** Profile key endpoints and add targeted includes/indexes where needed.
+- No runtime dependency remains on `Player` or `Participant` in active domain flows.
+- Teams reference users directly.
+- Game/match logic supports explicit team vs individual modes without participant abstraction.
+- Deleting/deactivating a user does not corrupt or invalidate historical competition records.
+- API behavior remains stable, with documented and intentional response changes only.
 
 ## Delivery estimate
-- Discovery + failure-case tests: 0.5–1 day
-- Data model + migration: 0.5 day
-- Service refactor + endpoint hardening: 1–2 days
-- Regression testing + cleanup: 0.5–1 day
+- Discovery + failing tests: 0.5–1 day
+- Compatibility layer + migrations: 1–1.5 days
+- Service refactor + deletion hardening: 1–2 days
+- Cleanup + regression stabilization: 0.5–1 day
 
-**Total:** ~2.5 to 4.5 engineering days
-
-
-## Estimation basis
-- The delivery estimate above is based on **one human engineer** working in this codebase with normal review/CI loops.
-- It assumes selective AI assistance (drafting/refactor support), **not** a fully autonomous agent shipping directly to production.
-- If executed by a highly capable autonomous agent with reliable repo context and test-fix loops, a best-case range could be lower (roughly **1 to 2.5 days**), but operational risk and verification overhead typically still require human sign-off.
+**Total:** ~3 to 5.5 engineering days

--- a/docs/phase-plans/README.md
+++ b/docs/phase-plans/README.md
@@ -1,0 +1,10 @@
+# Issue #47 + #50 Phase Plan Index
+
+This folder contains extensive, execution-level plans for each implementation phase.
+
+- [Phase 0 — Discovery and Failure Reproduction](./phase-0-discovery.md)
+- [Phase 1 — Compatibility Layer (Bridge Release)](./phase-1-compatibility-layer.md)
+- [Phase 2 — Data Model Transition](./phase-2-data-model-transition.md)
+- [Phase 3 — Domain and Service Refactor](./phase-3-domain-service-refactor.md)
+- [Phase 4 — Deletion Semantics Hardening](./phase-4-deletion-semantics.md)
+- [Phase 5 — Legacy Removal and Cleanup](./phase-5-legacy-cleanup.md)

--- a/docs/phase-plans/phase-0-discovery.md
+++ b/docs/phase-plans/phase-0-discovery.md
@@ -1,0 +1,47 @@
+# Phase 0 — Discovery and Failure Reproduction
+
+## 1) Purpose
+Create a factual baseline of current coupling and lock known failure modes into tests before refactoring.
+
+## 2) Inputs
+- Existing entities and EF relationship mappings.
+- Existing service/controller paths for game/match/team workflows.
+- Current issue requirements:
+  - #47: remove Player/Participant abstractions.
+  - #50: simplify and harden relation behavior.
+
+## 3) Detailed deliverables
+1. **Relation Matrix**
+   - Every entity relation with cardinality, optionality, delete behavior, and ownership semantics.
+   - "Historical data critical" marker for each relation.
+2. **Traversal Inventory**
+   - List of all deep relation walks in services/controllers.
+   - Risk tags: null-fragile, performance-sensitive, deletion-sensitive.
+3. **Failure Reproduction Tests**
+   - One failing case per known breakage category.
+4. **Refactor Impact Assessment**
+   - High/medium/low classification with estimated change blast radius.
+
+## 4) Work breakdown
+- Extract model relationship metadata from DB context and model classes.
+- Build a route-to-service-to-entity dependency map.
+- Author failing tests for:
+  - delete user/player then fetch game/match/team
+  - participant-missing assumptions in match generation
+- Document baseline API behavior and identify unstable contracts.
+
+## 5) Acceptance criteria
+- Matrix and traversal inventory reviewed by maintainers.
+- Failing test suite captures all known bug classes discussed in #47/#50.
+- Risks prioritized and linked to future phase tasks.
+
+## 6) Risks and mitigations
+- **Risk:** Incomplete dependency mapping.
+  - **Mitigation:** Pair route inventory with code search on entity names.
+- **Risk:** False negatives in failing tests.
+  - **Mitigation:** Add fixture realism (teams, matches, historical records).
+
+## 7) Output artifacts
+- `docs/internal/relation-matrix.md`
+- `docs/internal/traversal-inventory.md`
+- New failing tests in service/integration test projects.

--- a/docs/phase-plans/phase-1-compatibility-layer.md
+++ b/docs/phase-plans/phase-1-compatibility-layer.md
@@ -1,0 +1,40 @@
+# Phase 1 — Compatibility Layer (Bridge Release)
+
+## 1) Purpose
+Decouple callers from `Player` directly and introduce a stable user-centric resolution layer.
+
+## 2) Inputs
+- Phase 0 relation/traversal inventory.
+- Existing game/match team orchestration services.
+
+## 3) Detailed deliverables
+1. **Identity Resolution Abstraction**
+   - Interface for resolving competition identities without exposing legacy storage model.
+2. **Dual-path Adapter**
+   - Supports legacy player-backed and new user-backed lookup paths.
+3. **Incremental Service Adoption**
+   - High-traffic game/match endpoints switched first.
+4. **Contract Guard Tests**
+   - Ensure no endpoint response regression during compatibility period.
+
+## 4) Work breakdown
+- Define resolver contracts and DTO shapes.
+- Implement adapter with telemetry for path usage.
+- Replace direct player lookups in prioritized services.
+- Add tests for mixed data states (legacy + transitioned).
+
+## 5) Acceptance criteria
+- Critical flows resolve identities through abstraction only.
+- No outward API shape drift introduced in this phase.
+- Telemetry/logging can detect unresolved or ambiguous mappings.
+
+## 6) Risks and mitigations
+- **Risk:** Ambiguous identity mapping during dual-mode operation.
+  - **Mitigation:** Deterministic precedence and conflict logging.
+- **Risk:** Broad refactor too early.
+  - **Mitigation:** Limit adoption to highest-value paths first.
+
+## 7) Output artifacts
+- New resolver interface and implementation.
+- Service updates in selected game/match flows.
+- Unit tests for compatibility behavior.

--- a/docs/phase-plans/phase-2-data-model-transition.md
+++ b/docs/phase-plans/phase-2-data-model-transition.md
@@ -1,0 +1,42 @@
+# Phase 2 — Data Model Transition
+
+## 1) Purpose
+Move persistence model from Player/Participant-centric storage to User-centric and typed game/match representation.
+
+## 2) Inputs
+- Compatibility abstraction from Phase 1.
+- Existing production-like seeded snapshots.
+
+## 3) Detailed deliverables
+1. **Migration A — Profile consolidation**
+   - Move required Player profile fields to User-owned storage.
+2. **Migration B — Team membership update**
+   - Replace team-player with team-user relation.
+3. **Migration C — Participant transition**
+   - Introduce typed references for team/individual match and game modeling.
+4. **Backfill + Validation scripts**
+   - Idempotent scripts with row-count and constraint checks.
+5. **Rollback guidance**
+   - Explicit steps and preconditions for rollback.
+
+## 4) Work breakdown
+- Design additive-first migration sequence.
+- Run dry-run migration on snapshot data.
+- Backfill and verify field-level correctness.
+- Mark old structures deprecated but still readable until Phase 5.
+
+## 5) Acceptance criteria
+- Required player-owned data available under user ownership.
+- Team membership fully operational with users.
+- New writes no longer depend on participant-centric schema.
+
+## 6) Risks and mitigations
+- **Risk:** Data loss during consolidation.
+  - **Mitigation:** Pre/post migration audits + backup snapshot.
+- **Risk:** Non-idempotent backfill behavior.
+  - **Mitigation:** Safe upsert semantics and repeat-run checks.
+
+## 7) Output artifacts
+- Migration scripts and metadata.
+- Backfill tooling + validation report.
+- Schema change notes for reviewers.

--- a/docs/phase-plans/phase-3-domain-service-refactor.md
+++ b/docs/phase-plans/phase-3-domain-service-refactor.md
@@ -1,0 +1,40 @@
+# Phase 3 — Domain and Service Refactor
+
+## 1) Purpose
+Switch runtime logic to explicit team-vs-individual strategies and remove active dependency on Player/Participant abstractions.
+
+## 2) Inputs
+- Completed data transitions from Phase 2.
+- Compatibility adapter and service touchpoints from Phase 1.
+
+## 3) Detailed deliverables
+1. **Typed Strategy Layer**
+   - Distinct handling for team and individual game/match operations.
+2. **Service rewrite for core flows**
+   - Create/read/update logic based on user-centric relations.
+3. **Mapping overhaul**
+   - DTO/view-model mapping resilient to missing/deactivated users.
+4. **Error behavior standardization**
+   - Consistent not-found/inactive handling.
+
+## 4) Work breakdown
+- Implement strategy-dispatch for game/match operations.
+- Refactor services to eliminate participant traversal paths.
+- Update endpoint mappers and response builders.
+- Add regression tests for both team and individual modes.
+
+## 5) Acceptance criteria
+- No active business path requires Player/Participant runtime resolution.
+- Both competition modes pass functional tests.
+- Endpoint responses remain deterministic in edge cases.
+
+## 6) Risks and mitigations
+- **Risk:** Behavioral drift in bracket logic.
+  - **Mitigation:** Golden regression tests for bracket scenarios.
+- **Risk:** Performance regressions from lookup changes.
+  - **Mitigation:** Benchmark hot endpoints and optimize query includes/indexes.
+
+## 7) Output artifacts
+- Updated services and strategy modules.
+- Regression suite updates for mode coverage.
+- API behavior notes for any intentional changes.

--- a/docs/phase-plans/phase-4-deletion-semantics.md
+++ b/docs/phase-plans/phase-4-deletion-semantics.md
@@ -1,0 +1,40 @@
+# Phase 4 — Deletion Semantics Hardening
+
+## 1) Purpose
+Guarantee safe user deletion/deactivation without invalidating historical competition records.
+
+## 2) Inputs
+- Refactored user-centric service and schema model.
+- Existing deletion behavior and relation constraints.
+
+## 3) Detailed deliverables
+1. **Relationship rule hardening**
+   - Replace unsafe cascades with `Restrict` or `SetNull` where history must persist.
+2. **Deletion/deactivation workflow**
+   - Explicit command flow with validation, detach/reassign/archive policies.
+3. **End-to-end deletion regression tests**
+   - Delete/deactivate then read/update game, match, team resources.
+4. **Operational runbook snippet**
+   - Safe deletion procedures and troubleshooting notes.
+
+## 4) Work breakdown
+- Update EF relation config and generate migration if needed.
+- Implement service-level guards and deterministic outcomes.
+- Verify historical records remain readable and consistent.
+- Add integration tests for multiple role/team membership scenarios.
+
+## 5) Acceptance criteria
+- No destructive cascade into historical game/match data from user deletion paths.
+- Supported deletion/deactivation flows complete without referential errors.
+- Regression tests pass for delete-then-read/update scenarios.
+
+## 6) Risks and mitigations
+- **Risk:** Orphaned links with unclear presentation.
+  - **Mitigation:** Standard fallback payload fields and status flags.
+- **Risk:** Unexpected constraint failures in legacy data.
+  - **Mitigation:** Data cleanup pre-check and phased rollout.
+
+## 7) Output artifacts
+- EF configuration/migration updates.
+- Deletion workflow service code.
+- Integration test coverage and runbook notes.

--- a/docs/phase-plans/phase-5-legacy-cleanup.md
+++ b/docs/phase-plans/phase-5-legacy-cleanup.md
@@ -1,0 +1,40 @@
+# Phase 5 — Legacy Removal and Cleanup
+
+## 1) Purpose
+Complete the transition by removing deprecated models, fallback code, and obsolete schema artifacts.
+
+## 2) Inputs
+- Stable production-like validation from Phases 3 and 4.
+- Verification window confirming no legacy dependency.
+
+## 3) Detailed deliverables
+1. **Code cleanup**
+   - Remove `Player` and `Participant` artifacts and compatibility shims.
+2. **Schema cleanup migration**
+   - Drop deprecated columns/tables and stale constraints.
+3. **Documentation finalization**
+   - Update architecture docs, API notes, and changelog.
+4. **Post-migration verification report**
+   - Confirm no lingering references and no behavior regressions.
+
+## 4) Work breakdown
+- Delete legacy domain files and dead mappings.
+- Remove fallback branches from resolver/strategy code.
+- Run full regression and migration validation suite.
+- Publish final model diagram and maintenance notes.
+
+## 5) Acceptance criteria
+- Repository compiles/tests pass without legacy entities.
+- Schema is free of deprecated #47/#50 transitional artifacts.
+- Documentation reflects final, canonical model only.
+
+## 6) Risks and mitigations
+- **Risk:** Hidden runtime dependency on legacy objects.
+  - **Mitigation:** Static search gates and startup self-checks.
+- **Risk:** Documentation drift.
+  - **Mitigation:** Require docs update checklist in PR template.
+
+## 7) Output artifacts
+- Cleanup PRs and final migration.
+- Finalized architecture/API docs.
+- Closure report for both issues.


### PR DESCRIPTION
### Motivation
- Capture a coordinated, phase-based implementation strategy to remove `Player`/`Participant` abstractions and harden `Game`/`Match` relations for deletion safety. 
- Provide an execution-ready roadmap that prevents migration/service conflicts by sequencing compatibility, migrations, refactors, and cleanup. 
- Document acceptance criteria, rollout guidance, and estimated effort to align reviewers and implementation work.

### Description
- Add a new combined plan `docs/issue-47-50-phase-implementation-plan.md` that consolidates scope, phased deliverables (Phase 0..5), and cross-phase governance for both issues. 
- Replace and expand the previous `issue-50-plan.md` with a unified `Issue #47 + #50` plan that clarifies domain model targets and sequencing. 
- Add a `docs/phase-plans/README.md` index and detailed phase documents `phase-0` through `phase-5` under `docs/phase-plans/`, each describing purpose, deliverables, work breakdown, acceptance criteria, risks, and output artifacts. 
- The changes are documentation-only and introduce planned test/migration tasks (e.g., failing regression tests in Phase 0, migration/backfill scripts in Phase 2) but do not modify runtime code.

### Testing
- No automated tests were executed for this PR because it is documentation-only; no code behavior changed. 
- The plans document existing and planned automated tests (unit, integration, migration) to be added and run in later implementation PRs. 
- CI should remain green for code since only docs were added; any CI failures would be unrelated to runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c4638a808330bd49a3ceb71550a3)