### PR TITLE
Add PublicId & social-first password model, DB/DTO updates and login guard for social accounts

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,68 @@
+# ANALYSIS — Issue #48: Social login providers with internal user management
+
+## Updated direction
+
+Per latest product direction, user management remains internal to this API. The change is to add Google and Facebook as social login providers while improving security in login and registration flows.
+
+## Goal
+
+Enable sign-in/sign-up via Google and Facebook, map them to internally managed user accounts, and harden authentication and registration security controls.
+
+## Acceptance criteria
+
+1. Existing internal user management remains the source of truth for user records and profile data.
+2. Users can authenticate via Google and Facebook.
+3. Social identities are linked to a single internal user account model.
+4. Registration and login flows are hardened with explicit security controls (see below).
+5. Existing protected endpoints continue to enforce authorization correctly.
+6. Backward compatibility is preserved for existing non-social login users.
+
+## Security requirements for login/registration improvements
+
+- Strict token validation for external providers (issuer, audience, signature, expiry, nonce/state where applicable).
+- Verified-email handling policy for account creation/linking.
+- Safe account-linking rules to prevent accidental merges or account takeover.
+- Brute-force protection for local credential login (rate limiting/lockout policy aligned with current architecture).
+- Consistent error responses that do not leak account existence.
+- Audit logging for authentication and identity-link events.
+- CSRF/state protections for external auth callback flows.
+
+## Scope
+
+- Keep internal user management and existing user entity lifecycle.
+- Integrate Google and Facebook auth provider handling.
+- Add/update identity-link persistence between provider identities and internal users.
+- Update login/registration flows to support secure social sign-in and linking.
+- Add/update validation and security checks in auth endpoints/services.
+- Add tests for happy paths and security edge cases.
+
+## Out of scope
+
+- Migrating user management to external IdP.
+- Adding providers beyond Google/Facebook in this issue.
+- Frontend-specific UX redesign beyond required API contract changes.
+
+
+## Additional requirements from review
+
+- Prefer non-sequential public user identifiers (GUID/UUID) for externally exposed user references to reduce enumeration risk.
+- Define clear lifecycle for `PasswordHash`/`PasswordSalt` when a user is created through social-first registration.
+
+## Risks and constraints
+
+- Account linking mistakes could create duplicate users or takeover risk.
+- Provider claim differences and missing verified-email claims can complicate linking.
+- Callback/state handling errors can introduce auth vulnerabilities.
+- Existing clients may depend on current response shapes and error semantics.
+
+## Impacted areas (expected)
+
+- ASP.NET Core authentication configuration.
+- Auth controller/service login and registration workflows.
+- User and external-identity persistence model.
+- Validation, rate-limiting/lockout hooks, and auth audit logging.
+- Integration/unit tests for auth flows and security cases.
+
+## Next step in delivery flow
+
+Create `ARCHITECTURE.md` for implementation design (provider integration, identity-link model, secure flow updates, migration/backward-compat plan, and test matrix), then route to `developer-senior` due to cross-cutting auth/security/data changes.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,165 @@
+# ARCHITECTURE — Issue #48
+
+## Decision summary
+
+- Keep internal user management as system of record.
+- Add Google and Facebook as external social identity providers for authentication only.
+- Persist social identity links to internal users using a dedicated external-identity mapping model.
+- Harden login/registration flows with explicit security controls and auditability.
+- Route implementation to `developer-senior` due to cross-cutting auth, data, security, and migration impact.
+
+## Current-state assumptions to validate in code
+
+1. API currently supports internal authentication and protected endpoints.
+2. User domain model exists and is authoritative for profile/business data.
+3. No complete external-identity link model currently exists, or it is incomplete for multi-provider use.
+
+## Target architecture
+
+## Identifier strategy (user ids)
+
+- Use GUID/UUID for externally exposed user identifiers (API route ids, DTO references, tokens where applicable).
+- If internal PKs are currently integers, prefer one of:
+  1. Full migration to GUID PKs for user-related aggregates, or
+  2. Keep internal int PK and introduce immutable public `UserPublicId` (GUID) with unique index, using GUID for all external references.
+- Recommendation: **Option 2** for lower migration risk unless there is strong reason for full PK migration now.
+
+Security rationale:
+- Non-sequential identifiers reduce trivial enumeration and guessing of neighboring user ids.
+- This is defense-in-depth and must be combined with authorization checks on every resource access.
+
+### 1) Authentication boundary
+
+- External providers (Google/Facebook) authenticate end users.
+- API validates provider tokens and converts provider identity into an internal user principal.
+- Authorization inside API remains unchanged (role/claims/policies from internal model).
+
+### 2) Identity-link model
+
+Add a persistence model equivalent to:
+
+- `ExternalIdentity`
+  - `Id`
+  - `UserId` (FK to internal user)
+  - `Provider` (Google/Facebook enum/string)
+  - `ProviderSubject` (stable provider user id)
+  - `EmailAtLinkTime`
+  - `EmailVerifiedAtLinkTime` (bool)
+  - `CreatedAtUtc`
+  - `LastLoginAtUtc`
+  - unique index: (`Provider`, `ProviderSubject`)
+  - optional unique guard for trusted linking policy (e.g., verified email constraints as applicable)
+
+Rationale:
+- Supports one internal user linked to many providers.
+- Prevents duplicate mapping of same provider identity.
+
+### 3) Login/registration/link flows
+
+#### A. Social sign-in (existing user via existing link)
+1. Receive social token/assertion.
+2. Validate token cryptographically and semantically (issuer/audience/exp).
+3. Resolve (`Provider`, `ProviderSubject`) in `ExternalIdentity`.
+4. If found, authenticate as linked internal user.
+5. Update `LastLoginAtUtc`, emit audit event.
+
+#### B. Social first sign-in (no existing link)
+1. Validate token and required claims.
+2. Apply linking policy:
+   - If verified email matches exactly one eligible internal user and policy allows auto-link, create link.
+   - Else create controlled registration/link-intent flow requiring explicit confirmation.
+3. Persist initial profile fields when creating new user (first/last/email) per domain rules.
+4. Emit audit events for create/link outcome.
+
+#### C. Linking additional provider to authenticated account
+1. Require active internal authenticated session.
+2. Validate provider token.
+3. Ensure provider identity is not already linked elsewhere.
+4. Create `ExternalIdentity` row for current user.
+5. Audit success/failure.
+
+### 4) Security controls
+
+- Token validation:
+  - Verify signature via provider JWKS/official middleware.
+  - Enforce issuer and audience allow-lists.
+  - Enforce expiry/not-before and clock-skew bounds.
+- Callback/session protections:
+  - CSRF/state validation for auth initiation/callback patterns.
+  - Nonce validation where applicable.
+- Account takeover prevention:
+  - Never auto-link on unverified email.
+  - Block link when provider identity already belongs to different user.
+  - Use deterministic, reviewable linking policy.
+- Abuse resistance:
+  - Keep/extend local login rate limiting and lockout.
+  - Standardized auth errors (no user enumeration).
+- Observability:
+  - Structured security/audit logs for login, link, unlink, failures.
+
+### 4b) PasswordHash / PasswordSalt policy for social-first accounts
+
+For users created via social-first registration:
+- `PasswordHash` and `PasswordSalt` are nullable and remain `NULL` initially.
+- Account is flagged as social-auth-capable via linked `ExternalIdentity` records.
+- Local password login is disabled unless the user explicitly sets a password through a secure "set password" flow.
+
+When user sets a local password later:
+- Generate fresh salt and hash using current approved password hashing algorithm/work factor.
+- Store hash/salt and enable local-password auth for that account (if product policy allows hybrid auth).
+- Audit-log password set/reset and provider link state changes.
+
+Constraints:
+- Never create placeholder/default passwords for social-first users.
+- Enforce same password policy and reset protections as native accounts.
+
+### 5) API surface changes (conceptual)
+
+- Add/extend endpoints for:
+  - Social login callback/token exchange handling.
+  - Link social account to current internal account.
+  - Optional unlink endpoint with safety rules.
+- Keep response contracts backward compatible where possible.
+- Ensure cancellation token propagation and existing auth attributes remain consistent.
+
+### 6) Data and migration strategy
+
+- Add migration for `ExternalIdentity` table and indexes.
+- No destructive migration to internal user table required unless missing profile fields.
+- Backfill not required initially; links are created on-demand at first social login/link.
+
+### 7) Test strategy
+
+#### Unit tests
+- Token claim mapping and provider normalization.
+- Linking policy decisions (verified/unverified email, collisions).
+- Error mapping and non-enumerating responses.
+
+#### Integration tests
+- Existing link login succeeds.
+- First social login creates/links correctly under policy.
+- Duplicate provider-subject rejected.
+- Attempted takeover scenarios rejected.
+- Protected endpoints remain authorized as before with internal principal.
+
+#### Regression checks
+- Existing non-social login still works.
+- Existing authorization policies unaffected.
+- Social-first accounts cannot use local-password login before password is explicitly set.
+- After setting password, local login path works under normal policy controls.
+
+## Implementation plan (developer stage)
+
+1. Inspect current auth configuration and user model.
+2. Introduce `ExternalIdentity` entity + EF configuration + migration.
+3. Implement provider token validation abstraction.
+4. Implement social login and link flows in auth service/controller.
+5. Add audit logging and standardized error handling.
+6. Add/adjust unit + integration tests.
+7. Run verification commands from AGENTS.md subset.
+
+## Rollout notes
+
+- Feature-flag social login if operational risk is high.
+- Start with Google/Facebook only; keep provider abstraction extensible.
+- Monitor auth failure and link-collision metrics after release.

--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -1,0 +1,54 @@
+# DEVELOPMENT NOTES — Issue #48 (developer stage)
+
+## Implemented slice
+
+1. Added a non-sequential public identifier to `User`:
+   - `PublicId : Guid` defaulted at entity creation.
+   - Exposed via `GetUserDTO`.
+2. Made local password fields nullable for social-first users:
+   - `PasswordHash` and `Salt` are now nullable.
+   - EF model marks these columns optional.
+3. Hardened username/password login behavior:
+   - Login now rejects accounts without local password material (`PasswordHash`/`Salt`) as invalid credentials.
+
+## Security intent
+
+- `PublicId` supports using non-sequential external identifiers to reduce user-id enumeration risk.
+- Nullable password fields avoid fake/default passwords for social-first users.
+- Explicit login guard prevents accidental local-password auth for social-only accounts.
+
+## Environment limitation
+
+- Could not run build/tests because `dotnet` CLI is unavailable in this environment.
+
+## Dotnet CLI installation attempts
+
+Tried multiple installation paths to enable local validation:
+
+1. `curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh`
+   - Failed with HTTP 403.
+2. `wget -qO /tmp/dotnet-install.sh https://dot.net/v1/dotnet-install.sh`
+   - Failed due network/proxy restrictions.
+3. `apt-get update && apt-get install -y dotnet-sdk-8.0`
+   - Failed because apt repositories are blocked by proxy (HTTP 403).
+
+Given current environment network policy, .NET SDK cannot be installed from this container.
+
+## Retry after environment update
+
+Re-checked after environment update request:
+
+- `dotnet --info` still returns `dotnet: command not found`.
+- No `dotnet` binary found in common install locations (`/usr/share/dotnet`, `/usr/local/share/dotnet`) or shallow system search.
+
+Conclusion: .NET SDK/CLI is still not present in this container, so build/test validation remains blocked here.
+
+## Additional SDK acquisition attempts
+
+Further attempts made:
+
+- `curl https://aka.ms/dotnet-install.sh`
+- `curl https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh`
+- `curl https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.sh`
+
+All returned HTTP 403 in this environment, preventing SDK bootstrap.

--- a/src/MercuriusAPI/DTOs/Auth/GetUserDTO.cs
+++ b/src/MercuriusAPI/DTOs/Auth/GetUserDTO.cs
@@ -5,6 +5,7 @@ namespace Mercurius.LAN.API.DTOs.Auth;
 public class GetUserDTO
 {
     public int Id { get; set; }
+    public Guid PublicId { get; set; }
     public string Username { get; set; }
     public string Firstname { get; set; }
     public string Lastname { get; set; }
@@ -18,6 +19,7 @@ public class GetUserDTO
     public GetUserDTO(User user)
     {
         Id = user.Id;
+        PublicId = user.PublicId;
         Username = user.Username;
         Firstname = user.Firstname;
         Lastname = user.Lastname;

--- a/src/MercuriusAPI/Data/MercuriusDBContext.cs
+++ b/src/MercuriusAPI/Data/MercuriusDBContext.cs
@@ -32,6 +32,10 @@ public partial class MercuriusDBContext : DbContext
             entity.Property(e => e.Firstname).IsRequired();
             entity.Property(e => e.Lastname).IsRequired();
             entity.Property(e => e.Email).IsRequired();
+            entity.Property(e => e.PublicId).IsRequired();
+            entity.HasIndex(e => e.PublicId).IsUnique();
+            entity.Property(e => e.PasswordHash).IsRequired(false);
+            entity.Property(e => e.Salt).IsRequired(false);
         });
 
         modelBuilder.Entity<Team>(entity =>

--- a/src/MercuriusAPI/Models/Auth/User.cs
+++ b/src/MercuriusAPI/Models/Auth/User.cs
@@ -5,6 +5,7 @@ namespace Mercurius.LAN.API.Models;
 public class User
 {
     public int Id { get; set; }
+    public Guid PublicId { get; set; } = Guid.NewGuid();
     public string Username { get; set; } = string.Empty;
     public string Firstname { get; set; } = string.Empty;
     public string Lastname { get; set; } = string.Empty;
@@ -12,8 +13,8 @@ public class User
     public string? DiscordId { get; set; } = string.Empty;
     public string? SteamId { get; set; } = string.Empty;
     public string? RiotId { get; set; } = string.Empty;
-    public byte[] PasswordHash { get; set; } = [];
-    public byte[] Salt { get; set; } = [];
+    public byte[]? PasswordHash { get; set; }
+    public byte[]? Salt { get; set; }
     public ICollection<RefreshToken> RefreshTokens { get; set; } = new List<RefreshToken>();
     public ICollection<Role> Roles { get; set; } = new List<Role>();
 

--- a/src/MercuriusAPI/Services/Auth/AuthService.cs
+++ b/src/MercuriusAPI/Services/Auth/AuthService.cs
@@ -47,7 +47,8 @@ public class AuthService : IAuthService
             .Include(u => u.Roles)
             .FirstOrDefaultAsync(u => u.Username == normalizedUsername);
 
-        if (user == null || !PasswordHelper.VerifyPassword(request.Password, user.PasswordHash, user.Salt))
+        var hasLocalPassword = user?.PasswordHash is { Length: > 0 } && user.Salt is { Length: > 0 };
+        if (user == null || !hasLocalPassword || !PasswordHelper.VerifyPassword(request.Password, user.PasswordHash!, user.Salt!))
         {
             var attemptsLeft = _loginAttemptService.RegisterFailedAttempt(normalizedUsername, now);
             if (attemptsLeft == 0)

--- a/tests/MercuriusAPI.Tests/UserTests.cs
+++ b/tests/MercuriusAPI.Tests/UserTests.cs
@@ -39,6 +39,7 @@ public class UserTests
         var user = new User
         {
             Id = 7,
+            PublicId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
             Username = "playerone",
             Firstname = "Player",
             Lastname = "One",
@@ -52,6 +53,7 @@ public class UserTests
         var dto = new GetUserDTO(user);
 
         Assert.Equal(7, dto.Id);
+        Assert.Equal(Guid.Parse("11111111-1111-1111-1111-111111111111"), dto.PublicId);
         Assert.Equal("playerone", dto.Username);
         Assert.Equal("Player", dto.Firstname);
         Assert.Equal("One", dto.Lastname);
@@ -182,3 +184,18 @@ public class UserTests
         public Task RevokeRefreshTokenAsync(RevokeTokenRequest request) => Task.CompletedTask;
     }
 }
+
+
+    [Fact]
+    public void SocialFirstUser_HasNoLocalPasswordByDefault()
+    {
+        var user = new User
+        {
+            Username = "social-user",
+            Email = "social@test.com"
+        };
+
+        Assert.Null(user.PasswordHash);
+        Assert.Null(user.Salt);
+        Assert.NotEqual(Guid.Empty, user.PublicId);
+    }


### PR DESCRIPTION
### Motivation

- Implement groundwork for social login while keeping internal user management as the system of record and reducing user-id enumeration risk. 
- Support social-first accounts by avoiding placeholder passwords and explicitly disabling local-password login unless a password is set. 
- Harden authentication and registration flows with clear persistence and security intent documented for further implementation. 

### Description

- Add `PublicId : Guid` to the `User` model, expose it on `GetUserDTO`, add a unique index and require it at the EF model level. 
- Make `PasswordHash` and `Salt` nullable on the `User` entity and mark the columns optional in `MercuriusDBContext`. 
- Update `AuthService.LoginAsync` to treat accounts without local password material as invalid credentials and keep existing lockout/rate-limit behavior. 
- Add design and delivery documentation files (`ANALYSIS.md`, `ARCHITECTURE.md`, `DEVELOPMENT_NOTES.md`) describing identity-link model, security controls, migration strategy, and implementation plan. 
- Update unit tests in `UserTests` to assert `PublicId` mapping and add a `SocialFirstUser_HasNoLocalPasswordByDefault` test to verify social-first user defaults. 

### Testing

- No automated tests were executed in this environment because the `dotnet` CLI/SDK could not be installed due to network/proxy restrictions. 
- Unit tests were updated/added (`tests/MercuriusAPI.Tests/UserTests.cs`) to cover DTO mapping and social-first password behavior but remain unrun here. 
- Several attempts to install the .NET SDK (`dotnet-install.sh`, apt packages) failed with HTTP 403 or repository access errors, preventing local build/test validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71a2c089083309ff50d774cfe9d91)