### PR TITLE
Add authenticated user search

### DIFF
--- a/docs/issues/authenticated-user-search.md
+++ b/docs/issues/authenticated-user-search.md
@@ -1,0 +1,33 @@
+# Authenticated user search
+
+## Problem
+
+Authenticated application flows need a focused way to search users and receive the stable backend user id. The public global search endpoint is intentionally mixed-purpose navigation search and omits `userId` by design, so workflows such as team invitations must not depend on it.
+
+## Required contract
+
+Add authenticated, privacy-safe filtering on the existing users collection route:
+
+`GET /v1/lan/users?query={query}&cursor={cursor}&pageSize={pageSize}`
+
+The response uses the same pagination envelope as global search:
+
+- `results`: bounded user search results.
+- `nextCursor`: continuation cursor when more matches exist, otherwise `null`.
+- `hasMore`: whether another page is available.
+
+Each result includes:
+
+- `id`: stable backend `Guid` user id.
+- `type`: `user`.
+- `username`: public username.
+- `displayLabel`: selection label, initially the username.
+- `supportingText`: optional helper text, initially `User`.
+
+The endpoint must not expose private account fields such as email, Auth0 id, roles, deletion state, timestamps, or first/last name. It should return only active users with a usable username. Team invite flows can use the returned `id`, but the existing invite endpoint remains responsible for final team membership, pending invite, captain, and cooldown rules.
+
+## Notes
+
+This search is authenticated because it returns stable user ids for app workflows, even though the displayed user fields are public-safe. It is intentionally separate from global search so navigation search can remain public and id-free.
+
+The database must include endpoint-specific indexes for this access pattern: a PostgreSQL trigram index on active users with usernames for username matching, and a B-tree cursor index on normalized username plus id for deterministic page continuation.

--- a/openspec/changes/add-authenticated-user-search/.openspec.yaml
+++ b/openspec/changes/add-authenticated-user-search/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/add-authenticated-user-search/design.md
+++ b/openspec/changes/add-authenticated-user-search/design.md
@@ -1,0 +1,55 @@
+## Overview
+
+Add authenticated filtering to the users collection route. Search returns only public-safe user selection data plus the stable backend user id required by authenticated application workflows.
+
+## API
+
+Route:
+
+`GET /v1/lan/users?query={query}&cursor={cursor}&pageSize={pageSize}`
+
+Response:
+
+```json
+{
+  "results": [
+    {
+      "id": "00000000-0000-0000-0000-000000000000",
+      "type": "user",
+      "username": "PlayerOne",
+      "displayLabel": "PlayerOne",
+      "supportingText": "User"
+    }
+  ],
+  "nextCursor": null,
+  "hasMore": false
+}
+```
+
+The route uses the existing `/lan/users` collection resource. Supplying `query` returns privacy-safe search results to authenticated callers; omitting `query` preserves the existing admin-only list-all behavior.
+
+## Filtering
+
+The search uses normalized username matching and follows public user visibility rules:
+
+- exclude deleted users;
+- exclude users without a username or normalized username;
+- match case-insensitively;
+- return an empty list for very short queries.
+
+The endpoint does not pre-enforce workflow-specific rules such as team captainship, duplicate pending invites, existing membership, or cooldowns. Those remain enforced by their existing workflow mutations.
+
+## Bounds
+
+Use the existing search request limits for minimum query length, maximum query length, maximum cursor length, default page size, and maximum page size. Results are ordered deterministically by exact username match, prefix match, contains match, normalized username, and user id. Continuation uses an opaque keyset cursor compatible with the current query, mirroring global search behavior.
+
+## Indexes
+
+The migration adds PostgreSQL indexes scoped to active users with usernames:
+
+- `IX_Users_AuthenticatedSearch_NormalizedUsername_Trgm` supports exact, prefix, and contains matching on `NormalizedUsername`.
+- `IX_Users_AuthenticatedSearch_Cursor` supports deterministic ordering and keyset continuation by `NormalizedUsername` and `Id`.
+
+## Privacy
+
+The DTO intentionally omits email, email verification state, Auth0 id, roles, deleted state, first name, last name, platform ids, and timestamps. `displayLabel` mirrors `username` so no additional profile fields are introduced.

--- a/openspec/changes/add-authenticated-user-search/proposal.md
+++ b/openspec/changes/add-authenticated-user-search/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Authenticated app workflows need a stable backend user id when selecting users, but public global search intentionally returns navigation-only fields and omits user ids. Filtering the authenticated users collection keeps global search privacy semantics intact while providing a general user lookup contract.
+
+## What Changes
+
+- Add authenticated search/filtering to the existing users collection route using the existing search query, cursor, and page-size conventions.
+- Return a paged privacy-safe user search response with stable `id`, `type`, `username`, `displayLabel`, and optional `supportingText` results.
+- Exclude deleted users and users without usable usernames.
+- Preserve existing admin list behavior for `GET /v1/lan/users` when no `query` parameter is supplied.
+- Keep workflow-specific validation, such as team invite rules, in the existing workflow endpoints.
+
+## Capabilities
+
+### New Capabilities
+- `authenticated-user-search`: Authenticated privacy-safe user collection filtering for app workflows that need stable user ids.
+
+### Modified Capabilities
+- `user-owned-team-management`: Team invite flows can use authenticated user search to obtain recipient ids without changing invite mutation rules.
+
+## Impact
+
+- API: enhanced `GET /v1/lan/users?query={query}&cursor={cursor}&pageSize={pageSize}` collection route.
+- DTOs: new privacy-safe authenticated user search result shape.
+- Services: user service search method with query, cursor, and page-size bounds.
+- Tests: endpoint authorization/route coverage, service filtering/DTO privacy coverage.
+- No database migration, CORS, Auth0 configuration, or deployment variable changes expected.

--- a/openspec/changes/add-authenticated-user-search/proposal.md
+++ b/openspec/changes/add-authenticated-user-search/proposal.md
@@ -24,4 +24,5 @@ Authenticated app workflows need a stable backend user id when selecting users, 
 - DTOs: new privacy-safe authenticated user search result shape.
 - Services: user service search method with query, cursor, and page-size bounds.
 - Tests: endpoint authorization/route coverage, service filtering/DTO privacy coverage.
-- No database migration, CORS, Auth0 configuration, or deployment variable changes expected.
+- Database: EF migration adds the PostgreSQL `pg_trgm` extension if needed and authenticated user search indexes on active users with usernames.
+- No CORS, Auth0 configuration, or deployment variable changes expected.

--- a/openspec/changes/add-authenticated-user-search/specs/authenticated-user-search/spec.md
+++ b/openspec/changes/add-authenticated-user-search/specs/authenticated-user-search/spec.md
@@ -32,6 +32,10 @@ Authenticated user search MUST support a query string, continuation cursor, and 
 - **WHEN** a client searches with a query beyond the configured maximum search length
 - **THEN** the API rejects the request with validation failure
 
+#### Scenario: Search requests are rate limited
+- **WHEN** an authenticated client searches the users collection
+- **THEN** the request is subject to the API search rate limit policy
+
 ### Requirement: User search response shape
 Authenticated user search results MUST include only the fields needed for user selection, plus pagination metadata aligned with global search.
 

--- a/openspec/changes/add-authenticated-user-search/specs/authenticated-user-search/spec.md
+++ b/openspec/changes/add-authenticated-user-search/specs/authenticated-user-search/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Authenticated user search
+The API MUST support authenticated filtering of the users collection with `GET /v1/lan/users?query={query}`.
+
+#### Scenario: Authenticated caller searches users
+- **WHEN** an authenticated client searches with a valid query
+- **THEN** the response includes matching user search results
+- **AND** each result includes the stable backend user id
+
+#### Scenario: Anonymous caller rejected
+- **WHEN** an anonymous client searches the users collection
+- **THEN** the API rejects the request as unauthorized
+
+### Requirement: User search request bounds
+Authenticated user search MUST support a query string, continuation cursor, and bounded page size.
+
+#### Scenario: Short query returns no candidates
+- **WHEN** a client searches with fewer than three trimmed characters
+- **THEN** the response returns an empty candidate list
+
+#### Scenario: Result count is bounded
+- **WHEN** more users match than the requested or default page size allows
+- **THEN** the response contains no more than the bounded page size
+
+#### Scenario: Continue user search
+- **WHEN** more users match a valid query than fit in the first response page
+- **THEN** the response includes `nextCursor`
+- **AND** the client can request the next page with the same query and returned cursor
+
+#### Scenario: Overlong query rejected
+- **WHEN** a client searches with a query beyond the configured maximum search length
+- **THEN** the API rejects the request with validation failure
+
+### Requirement: User search response shape
+Authenticated user search results MUST include only the fields needed for user selection, plus pagination metadata aligned with global search.
+
+#### Scenario: Search response envelope
+- **WHEN** a user search request is processed
+- **THEN** the response includes `results`
+- **AND** the response includes `nextCursor`
+- **AND** the response includes `hasMore`
+
+#### Scenario: Candidate fields returned
+- **WHEN** a user candidate is returned
+- **THEN** it includes `id`, `type`, `username`, `displayLabel`, and `supportingText`
+
+#### Scenario: Private fields omitted
+- **WHEN** user candidates are returned
+- **THEN** the response omits email, Auth0 id, roles, deletion state, first name, last name, platform ids, and timestamps
+
+### Requirement: User search privacy filtering
+Authenticated user search MUST return only privacy-safe active users with usable usernames.
+
+#### Scenario: Deleted and username-less users excluded
+- **WHEN** deleted users or users without usernames match the query
+- **THEN** they are excluded from user search results
+
+#### Scenario: Case-insensitive username matching
+- **WHEN** a client searches using different casing than stored usernames
+- **THEN** matching is case-insensitive
+
+### Requirement: User search database indexes
+Authenticated user search MUST include database indexes aligned with username matching and cursor continuation.
+
+#### Scenario: Username matching index exists
+- **WHEN** authenticated user search is deployed to PostgreSQL
+- **THEN** the database includes a trigram index on active users' normalized usernames
+
+#### Scenario: Cursor ordering index exists
+- **WHEN** authenticated user search is deployed to PostgreSQL
+- **THEN** the database includes an index supporting normalized username and user id ordering for active users with usernames

--- a/openspec/changes/add-authenticated-user-search/specs/user-owned-team-management/spec.md
+++ b/openspec/changes/add-authenticated-user-search/specs/user-owned-team-management/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Team invitation lifecycle
+The API MUST track team invitations with Pending, Accepted, Declined, Cancelled, and Expired states, and team invite clients MAY use authenticated user search to discover stable recipient user ids before sending an invite.
+
+#### Scenario: Captain sends invite
+- **WHEN** a captain invites an existing user who is not already a team member
+- **THEN** the API creates a pending invite for that user and team
+
+#### Scenario: Duplicate pending invite blocked
+- **WHEN** a pending invite already exists for the same user and team
+- **THEN** the API rejects another invite for that user and team
+
+#### Scenario: Declined invite resend allowance not exhausted
+- **WHEN** a user declined a team invite and the configured declined-invite resend allowance has not been exhausted
+- **THEN** the API allows the captain to send another invite for that user and team when no pending invite exists
+
+#### Scenario: Declined invite cooldown enforced after resend allowance
+- **WHEN** a user has declined the configured number of resend attempts for a team and the resend cooldown has not elapsed
+- **THEN** the API rejects a new invite for that user and team
+
+#### Scenario: Captain cancels pending invite
+- **WHEN** the team captain cancels a pending invite for their team
+- **THEN** the API marks the invite as cancelled and excludes it from recipient pending-invite lists
+
+#### Scenario: Accepted or declined invite cannot be cancelled
+- **WHEN** a captain attempts to cancel an invite that is not pending
+- **THEN** the API rejects the cancellation without changing the invite status
+
+#### Scenario: Pending invite expires
+- **WHEN** a pending invite reaches its configured expiration time
+- **THEN** the API treats the invite as expired and excludes it from actionable pending invite lists
+
+#### Scenario: Expired invite cannot be answered
+- **WHEN** a user attempts to accept or decline an expired invite
+- **THEN** the API rejects the request without changing membership
+
+#### Scenario: User search does not replace invite validation
+- **WHEN** a client sends an invite using a user id discovered through authenticated user search
+- **THEN** the existing invite endpoint still enforces captainship, membership, duplicate invite, expiration, and cooldown rules before creating the invite

--- a/openspec/changes/add-authenticated-user-search/tasks.md
+++ b/openspec/changes/add-authenticated-user-search/tasks.md
@@ -1,0 +1,18 @@
+## 1. OpenSpec and Brief
+
+- [x] Create local issue brief documenting why global search is insufficient and the required authenticated user search contract.
+- [x] Add OpenSpec proposal, design, and spec deltas for authenticated user search.
+
+## 2. API Implementation
+
+- [x] Add a privacy-safe user search result DTO.
+- [x] Add user service lookup method with normalized query matching, bounded page size, and cursor continuation.
+- [x] Map authenticated `GET /v1/lan/users?query={query}` on the existing users collection route.
+- [x] Add PostgreSQL indexes for authenticated user search matching and cursor continuation.
+
+## 3. Verification
+
+- [x] Add route authorization and service/privacy tests.
+- [x] Run `dotnet build LAN.API.sln`.
+- [x] Run `dotnet test LAN.API.sln`.
+- [x] Update this checklist after implementation and verification.

--- a/openspec/changes/add-authenticated-user-search/tasks.md
+++ b/openspec/changes/add-authenticated-user-search/tasks.md
@@ -8,11 +8,13 @@
 - [x] Add a privacy-safe user search result DTO.
 - [x] Add user service lookup method with normalized query matching, bounded page size, and cursor continuation.
 - [x] Map authenticated `GET /v1/lan/users?query={query}` on the existing users collection route.
+- [x] Apply the existing search rate-limit setup to authenticated user search requests.
 - [x] Add PostgreSQL indexes for authenticated user search matching and cursor continuation.
 
 ## 3. Verification
 
 - [x] Add route authorization and service/privacy tests.
+- [x] Add query translation and rate-limit metadata tests for authenticated user search.
 - [x] Run `dotnet build LAN.API.sln`.
 - [x] Run `dotnet test LAN.API.sln`.
 - [x] Update this checklist after implementation and verification.

--- a/src/MercuriusAPI/DTOs/Auth/UserSearchResponseDTO.cs
+++ b/src/MercuriusAPI/DTOs/Auth/UserSearchResponseDTO.cs
@@ -1,0 +1,10 @@
+namespace Mercurius.LAN.API.DTOs.Auth;
+
+public sealed class UserSearchResponseDTO
+{
+    public IReadOnlyList<UserSearchResultDTO> Results { get; init; } = [];
+
+    public string? NextCursor { get; init; }
+
+    public bool HasMore { get; init; }
+}

--- a/src/MercuriusAPI/DTOs/Auth/UserSearchResultDTO.cs
+++ b/src/MercuriusAPI/DTOs/Auth/UserSearchResultDTO.cs
@@ -1,0 +1,10 @@
+namespace Mercurius.LAN.API.DTOs.Auth;
+
+public sealed class UserSearchResultDTO
+{
+    public required Guid Id { get; init; }
+    public required string Type { get; init; }
+    public required string Username { get; init; }
+    public required string DisplayLabel { get; init; }
+    public string? SupportingText { get; init; }
+}

--- a/src/MercuriusAPI/Endpoints/SearchEndpoints.cs
+++ b/src/MercuriusAPI/Endpoints/SearchEndpoints.cs
@@ -21,14 +21,10 @@ public static class SearchEndpoints
 
         group.MapGet("/", async (string? query, string? cursor, int? pageSize, ISearchService searchService, CancellationToken cancellationToken) =>
         {
-            var normalizedQuery = (query ?? string.Empty).Trim();
-            if (normalizedQuery.Length > SearchRequestLimits.MaximumQueryLength)
-                throw new ValidationException($"Query cannot exceed {SearchRequestLimits.MaximumQueryLength} characters.");
+            SearchRequest.ValidateQueryLength(SearchRequest.NormalizeQuery(query));
+            SearchRequest.ValidatePageSize(pageSize);
 
-            if (pageSize is <= 0)
-                throw new ValidationException("pageSize must be greater than 0.");
-
-            var boundedPageSize = Math.Min(pageSize ?? SearchRequestLimits.DefaultPageSize, SearchRequestLimits.MaximumPageSize);
+            var boundedPageSize = SearchRequest.BoundPageSize(pageSize);
 
             return await searchService.SearchAsync(query, cursor, boundedPageSize, cancellationToken);
         })

--- a/src/MercuriusAPI/Endpoints/UserEndpoints.cs
+++ b/src/MercuriusAPI/Endpoints/UserEndpoints.cs
@@ -1,5 +1,7 @@
 using Asp.Versioning;
 using Mercurius.LAN.API.DTOs.Auth;
+using Mercurius.LAN.API.Exceptions;
+using Mercurius.LAN.API.Services.SearchServices;
 using Mercurius.LAN.API.Services.UserServices;
 using Microsoft.AspNetCore.Authorization;
 using System.Security.Claims;
@@ -55,6 +57,28 @@ public static class UserEndpoints
         })
         .RequireAuthorization();
 
+        group.MapGet("/", async (HttpRequest request, string? query, string? cursor, int? pageSize, ClaimsPrincipal user, IUserService userService, CancellationToken cancellationToken) =>
+        {
+            if (request.Query.ContainsKey("query"))
+            {
+                var normalizedQuery = (query ?? string.Empty).Trim();
+                if (normalizedQuery.Length > SearchRequestLimits.MaximumQueryLength)
+                    throw new ValidationException($"Query cannot exceed {SearchRequestLimits.MaximumQueryLength} characters.");
+
+                if (pageSize is <= 0)
+                    throw new ValidationException("pageSize must be greater than 0.");
+
+                var boundedPageSize = Math.Min(pageSize ?? SearchRequestLimits.DefaultPageSize, SearchRequestLimits.MaximumPageSize);
+                return Results.Ok(await userService.SearchUsersAsync(query, cursor, boundedPageSize, cancellationToken));
+            }
+
+            if (!user.IsInRole("admin"))
+                return Results.Forbid();
+
+            return Results.Ok(await userService.GetAllUsersAsync());
+        })
+        .RequireAuthorization();
+
         group.MapPost("/me/resend-verification-email", async (ClaimsPrincipal user, IUserService userService) =>
         {
             return await userService.ResendVerificationEmailAsync(GetAuth0UserId(user));
@@ -84,11 +108,6 @@ public static class UserEndpoints
         adminGroup.MapGet("/{id:guid}", async (Guid id, IUserService userService) =>
         {
             return await userService.GetUserByIdAsync(id);
-        });
-
-        adminGroup.MapGet("/", async (IUserService userService) =>
-        {
-            return await userService.GetAllUsersAsync();
         });
 
         adminGroup.MapPatch("/{id:guid}", async (Guid id, UpdateUserProfileRequest request, IUserService userService) =>

--- a/src/MercuriusAPI/Endpoints/UserEndpoints.cs
+++ b/src/MercuriusAPI/Endpoints/UserEndpoints.cs
@@ -1,6 +1,6 @@
 using Asp.Versioning;
 using Mercurius.LAN.API.DTOs.Auth;
-using Mercurius.LAN.API.Exceptions;
+using Mercurius.LAN.API.Extensions;
 using Mercurius.LAN.API.Services.SearchServices;
 using Mercurius.LAN.API.Services.UserServices;
 using Microsoft.AspNetCore.Authorization;
@@ -61,14 +61,10 @@ public static class UserEndpoints
         {
             if (request.Query.ContainsKey("query"))
             {
-                var normalizedQuery = (query ?? string.Empty).Trim();
-                if (normalizedQuery.Length > SearchRequestLimits.MaximumQueryLength)
-                    throw new ValidationException($"Query cannot exceed {SearchRequestLimits.MaximumQueryLength} characters.");
+                SearchRequest.ValidateQueryLength(SearchRequest.NormalizeQuery(query));
+                SearchRequest.ValidatePageSize(pageSize);
 
-                if (pageSize is <= 0)
-                    throw new ValidationException("pageSize must be greater than 0.");
-
-                var boundedPageSize = Math.Min(pageSize ?? SearchRequestLimits.DefaultPageSize, SearchRequestLimits.MaximumPageSize);
+                var boundedPageSize = SearchRequest.BoundPageSize(pageSize);
                 return Results.Ok(await userService.SearchUsersAsync(query, cursor, boundedPageSize, cancellationToken));
             }
 
@@ -77,7 +73,8 @@ public static class UserEndpoints
 
             return Results.Ok(await userService.GetAllUsersAsync());
         })
-        .RequireAuthorization();
+        .RequireAuthorization()
+        .RequireRateLimiting(RateLimitPolicies.AuthenticatedSearch);
 
         group.MapPost("/me/resend-verification-email", async (ClaimsPrincipal user, IUserService userService) =>
         {

--- a/src/MercuriusAPI/Extensions/RateLimitingConfiguration.cs
+++ b/src/MercuriusAPI/Extensions/RateLimitingConfiguration.cs
@@ -7,6 +7,7 @@ namespace Mercurius.LAN.API.Extensions;
 public static class RateLimitPolicies
 {
     public const string AnonymousSearch = "anonymous-search";
+    public const string AuthenticatedSearch = "authenticated-search";
 }
 
 public static class RateLimitingConfiguration
@@ -25,6 +26,10 @@ public static class RateLimitingConfiguration
                 CreateFixedWindowPartition(httpContext, globalPermitLimit, window));
             options.AddPolicy(RateLimitPolicies.AnonymousSearch, httpContext =>
                 CreateFixedWindowPartition(httpContext, searchPermitLimit, window));
+            options.AddPolicy(RateLimitPolicies.AuthenticatedSearch, httpContext =>
+                httpContext.Request.Query.ContainsKey("query")
+                    ? CreateFixedWindowPartition(httpContext, searchPermitLimit, window)
+                    : RateLimitPartition.GetNoLimiter(GetPartitionKey(httpContext)));
             options.OnRejected = async (context, cancellationToken) =>
             {
                 if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))

--- a/src/MercuriusAPI/Migrations/20260605204500_AuthenticatedUserSearchIndexes.cs
+++ b/src/MercuriusAPI/Migrations/20260605204500_AuthenticatedUserSearchIndexes.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Mercurius.LAN.API.Migrations
+{
+    /// <inheritdoc />
+    [Migration("20260605204500_AuthenticatedUserSearchIndexes")]
+    public partial class AuthenticatedUserSearchIndexes : Migration
+    {
+        private const string ActiveCompleteUserPredicate = """
+            "NormalizedUsername" IS NOT NULL
+            AND "Username" IS NOT NULL
+            AND "Username" <> ''
+            AND "NormalizedUsername" <> ''
+            AND "IsDeleted" = false
+            """;
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""CREATE EXTENSION IF NOT EXISTS pg_trgm;""");
+            migrationBuilder.Sql($"""
+                CREATE INDEX "IX_Users_AuthenticatedSearch_NormalizedUsername_Trgm"
+                ON "Users" USING gin ("NormalizedUsername" gin_trgm_ops)
+                WHERE {ActiveCompleteUserPredicate};
+                """);
+            migrationBuilder.Sql($"""
+                CREATE INDEX "IX_Users_AuthenticatedSearch_Cursor"
+                ON "Users" ("NormalizedUsername", "Id")
+                WHERE {ActiveCompleteUserPredicate};
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""DROP INDEX "IX_Users_AuthenticatedSearch_Cursor";""");
+            migrationBuilder.Sql("""DROP INDEX "IX_Users_AuthenticatedSearch_NormalizedUsername_Trgm";""");
+        }
+    }
+}

--- a/src/MercuriusAPI/Services/SearchServices/SearchCursorCodec.cs
+++ b/src/MercuriusAPI/Services/SearchServices/SearchCursorCodec.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using Mercurius.LAN.API.Exceptions;
+
+namespace Mercurius.LAN.API.Services.SearchServices;
+
+public static class SearchCursorCodec
+{
+    public static string Encode<TCursor>(TCursor cursor)
+    {
+        return Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(cursor));
+    }
+
+    public static TCursor? Decode<TCursor>(
+        string? cursor,
+        string normalizedQuery,
+        Func<TCursor, bool> isValid,
+        Func<TCursor, string> getQuery)
+        where TCursor : class
+    {
+        if (string.IsNullOrWhiteSpace(cursor))
+            return null;
+
+        if (cursor.Length > SearchRequestLimits.MaximumCursorLength)
+            throw new ValidationException("Cursor is invalid.");
+
+        try
+        {
+            var payload = JsonSerializer.Deserialize<TCursor>(Convert.FromBase64String(cursor));
+            if (payload is null || !isValid(payload))
+                throw new ValidationException("Cursor is invalid.");
+
+            if (!string.Equals(getQuery(payload), normalizedQuery, StringComparison.Ordinal))
+                throw new ValidationException("Cursor does not match query.");
+
+            return payload;
+        }
+        catch (Exception exception) when (exception is FormatException or JsonException)
+        {
+            throw new ValidationException("Cursor is invalid.");
+        }
+    }
+}

--- a/src/MercuriusAPI/Services/SearchServices/SearchRequest.cs
+++ b/src/MercuriusAPI/Services/SearchServices/SearchRequest.cs
@@ -1,0 +1,41 @@
+using Mercurius.LAN.API.Exceptions;
+
+namespace Mercurius.LAN.API.Services.SearchServices;
+
+public static class SearchRequest
+{
+    public static string NormalizeQuery(string? query)
+    {
+        return (query ?? string.Empty).Trim().ToLowerInvariant();
+    }
+
+    public static void ValidateQueryLength(string normalizedQuery)
+    {
+        if (normalizedQuery.Length > SearchRequestLimits.MaximumQueryLength)
+            throw new ValidationException($"Query cannot exceed {SearchRequestLimits.MaximumQueryLength} characters.");
+    }
+
+    public static void ValidatePageSize(int? pageSize)
+    {
+        if (pageSize is <= 0)
+            throw new ValidationException("pageSize must be greater than 0.");
+    }
+
+    public static int BoundPageSize(int? pageSize)
+    {
+        return Math.Min(pageSize ?? SearchRequestLimits.DefaultPageSize, SearchRequestLimits.MaximumPageSize);
+    }
+
+    public static int BoundPageSize(int pageSize)
+    {
+        return Math.Clamp(pageSize, 1, SearchRequestLimits.MaximumPageSize);
+    }
+
+    public static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal);
+    }
+}

--- a/src/MercuriusAPI/Services/SearchServices/SearchService.cs
+++ b/src/MercuriusAPI/Services/SearchServices/SearchService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Mercurius.LAN.API.Data;
 using Mercurius.LAN.API.DTOs.SearchDTOs;
 using Mercurius.LAN.API.Exceptions;
@@ -17,11 +16,10 @@ public sealed class SearchService : ISearchService
 
     public async Task<SearchResponseDTO> SearchAsync(string? query, string? cursor, int pageSize, CancellationToken cancellationToken = default)
     {
-        var normalizedQuery = NormalizeQuery(query);
-        if (normalizedQuery.Length > SearchRequestLimits.MaximumQueryLength)
-            throw new ValidationException($"Query cannot exceed {SearchRequestLimits.MaximumQueryLength} characters.");
+        var normalizedQuery = SearchRequest.NormalizeQuery(query);
+        SearchRequest.ValidateQueryLength(normalizedQuery);
 
-        var boundedPageSize = Math.Clamp(pageSize, 1, SearchRequestLimits.MaximumPageSize);
+        var boundedPageSize = SearchRequest.BoundPageSize(pageSize);
         if (normalizedQuery.Length < SearchRequestLimits.MinimumQueryLength)
             return new SearchResponseDTO { Results = [], HasMore = false };
 
@@ -43,8 +41,9 @@ public sealed class SearchService : ISearchService
 
     private IQueryable<SearchCandidate> BuildCandidateQuery(string normalizedQuery)
     {
-        var containsPattern = $"%{EscapeLikePattern(normalizedQuery)}%";
-        var prefixPattern = $"{EscapeLikePattern(normalizedQuery)}%";
+        var escapedQuery = SearchRequest.EscapeLikePattern(normalizedQuery);
+        var containsPattern = $"%{escapedQuery}%";
+        var prefixPattern = $"{escapedQuery}%";
 
         var users = _dbContext.Users
             .AsNoTracking()
@@ -140,19 +139,6 @@ public sealed class SearchService : ISearchService
              string.Compare(candidate.StableId, cursor.StableId) > 0));
     }
 
-    private static string NormalizeQuery(string? query)
-    {
-        return (query ?? string.Empty).Trim().ToLowerInvariant();
-    }
-
-    private static string EscapeLikePattern(string value)
-    {
-        return value
-            .Replace("\\", "\\\\", StringComparison.Ordinal)
-            .Replace("%", "\\%", StringComparison.Ordinal)
-            .Replace("_", "\\_", StringComparison.Ordinal);
-    }
-
     private static SearchResultDTO ToResult(SearchCandidate candidate)
     {
         return new SearchResultDTO
@@ -175,37 +161,21 @@ public sealed class SearchService : ISearchService
     private static string BuildCursor(string normalizedQuery, SearchCandidate candidate)
     {
         var payload = new SearchCursor(normalizedQuery, candidate.RelevanceRank, candidate.NormalizedLabel, candidate.TypeOrder, candidate.StableId);
-        return Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(payload));
+        return SearchCursorCodec.Encode(payload);
     }
 
     private static SearchCursor? DecodeCursor(string? cursor, string normalizedQuery)
     {
-        if (string.IsNullOrWhiteSpace(cursor))
-            return null;
-
-        if (cursor.Length > SearchRequestLimits.MaximumCursorLength)
-            throw new ValidationException("Cursor is invalid.");
-
-        try
-        {
-            var payload = JsonSerializer.Deserialize<SearchCursor>(Convert.FromBase64String(cursor));
-            if (payload is null ||
-                string.IsNullOrEmpty(payload.Query) ||
-                payload.RelevanceRank is < 0 or > 2 ||
-                string.IsNullOrEmpty(payload.NormalizedLabel) ||
-                payload.TypeOrder is < 0 or > 2 ||
-                !Guid.TryParse(payload.StableId, out _))
-                throw new ValidationException("Cursor is invalid.");
-
-            if (!string.Equals(payload.Query, normalizedQuery, StringComparison.Ordinal))
-                throw new ValidationException("Cursor does not match query.");
-
-            return payload;
-        }
-        catch (Exception exception) when (exception is FormatException or JsonException)
-        {
-            throw new ValidationException("Cursor is invalid.");
-        }
+        return SearchCursorCodec.Decode<SearchCursor>(
+            cursor,
+            normalizedQuery,
+            payload =>
+                !string.IsNullOrEmpty(payload.Query) &&
+                payload.RelevanceRank is >= 0 and <= 2 &&
+                !string.IsNullOrEmpty(payload.NormalizedLabel) &&
+                payload.TypeOrder is >= 0 and <= 2 &&
+                Guid.TryParse(payload.StableId, out _),
+            payload => payload.Query);
     }
 
     private sealed class SearchCandidate

--- a/src/MercuriusAPI/Services/UserServices/IUserService.cs
+++ b/src/MercuriusAPI/Services/UserServices/IUserService.cs
@@ -8,6 +8,7 @@ public interface IUserService
     Task<GetUserDTO> CompleteProfileAsync(string auth0UserId, CompleteUserProfileRequest request);
     Task<CurrentUserProfileResponse> GetCurrentUserAsync(string auth0UserId);
     Task<PublicUserProfileDTO> GetPublicUserProfileByUsernameAsync(string username);
+    Task<UserSearchResponseDTO> SearchUsersAsync(string? query, string? cursor, int pageSize, CancellationToken cancellationToken = default);
     Task<GetUserDTO> UpdateCurrentUserAsync(string auth0UserId, UpdateUserProfileRequest request);
     Task<UsernameAvailabilityResponse> CheckUsernameAvailabilityAsync(string auth0UserId, string username);
     Task<UserActionResponse> ResendVerificationEmailAsync(string auth0UserId);

--- a/src/MercuriusAPI/Services/UserServices/UserService.cs
+++ b/src/MercuriusAPI/Services/UserServices/UserService.cs
@@ -1,8 +1,10 @@
+using System.Text.Json;
 using Mercurius.LAN.API.Data;
 using Mercurius.LAN.API.DTOs.Auth;
 using Mercurius.LAN.API.Exceptions;
 using Mercurius.LAN.API.Models;
 using Mercurius.LAN.API.Services.Auth0;
+using Mercurius.LAN.API.Services.SearchServices;
 using Microsoft.EntityFrameworkCore;
 
 namespace Mercurius.LAN.API.Services.UserServices;
@@ -92,6 +94,95 @@ public class UserService : IUserService
             throw new NotFoundException($"User '{trimmedUsername}' not found.");
 
         return profile;
+    }
+
+    public async Task<UserSearchResponseDTO> SearchUsersAsync(
+        string? query,
+        string? cursor,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedQuery = (query ?? string.Empty).Trim().ToLowerInvariant();
+        if (normalizedQuery.Length > SearchRequestLimits.MaximumQueryLength)
+            throw new ValidationException($"Query cannot exceed {SearchRequestLimits.MaximumQueryLength} characters.");
+
+        if (normalizedQuery.Length < SearchRequestLimits.MinimumQueryLength)
+            return new UserSearchResponseDTO { Results = [], HasMore = false };
+
+        var boundedPageSize = Math.Clamp(pageSize, 1, SearchRequestLimits.MaximumPageSize);
+        var decodedCursor = DecodeUserSearchCursor(cursor, normalizedQuery);
+        var users = await BuildPagedUserSearchQuery(normalizedQuery, decodedCursor, boundedPageSize + 1)
+            .ToListAsync(cancellationToken);
+
+        var hasMore = users.Count > boundedPageSize;
+        if (hasMore)
+            users.RemoveAt(users.Count - 1);
+
+        return new UserSearchResponseDTO
+        {
+            Results = users.Select(ToUserSearchResult).ToList(),
+            NextCursor = hasMore ? BuildUserSearchCursor(normalizedQuery, users[^1]) : null,
+            HasMore = hasMore
+        };
+    }
+
+    private IQueryable<UserSearchCandidate> BuildPagedUserSearchQuery(string normalizedQuery, UserSearchCursor? cursor, int limit)
+    {
+        return ApplyUserSearchCursor(BuildUserSearchQuery(normalizedQuery), cursor)
+            .OrderBy(user => user.RelevanceRank)
+            .ThenBy(user => user.NormalizedUsername)
+            .ThenBy(user => user.StableId)
+            .Take(limit);
+    }
+
+    private IQueryable<UserSearchCandidate> BuildUserSearchQuery(string normalizedQuery)
+    {
+        var containsPattern = $"%{EscapeLikePattern(normalizedQuery)}%";
+        var prefixPattern = $"{EscapeLikePattern(normalizedQuery)}%";
+
+        return _dbContext.Users
+            .AsNoTracking()
+            .Where(user =>
+                !user.IsDeleted &&
+                !string.IsNullOrEmpty(user.Username) &&
+                !string.IsNullOrEmpty(user.NormalizedUsername) &&
+                EF.Functions.Like(user.NormalizedUsername, containsPattern, "\\"))
+            .Select(user => new UserSearchCandidate
+            {
+                Id = user.Id,
+                RelevanceRank = user.NormalizedUsername == normalizedQuery
+                    ? 0
+                    : EF.Functions.Like(user.NormalizedUsername, prefixPattern, "\\") ? 1 : 2,
+                NormalizedUsername = user.NormalizedUsername!,
+                Username = user.Username!,
+                StableId = user.Id.ToString()
+            });
+    }
+
+    private static IQueryable<UserSearchCandidate> ApplyUserSearchCursor(IQueryable<UserSearchCandidate> candidates, UserSearchCursor? cursor)
+    {
+        if (cursor is null)
+            return candidates;
+
+        return candidates.Where(candidate =>
+            (candidate.RelevanceRank > cursor.RelevanceRank) ||
+            (candidate.RelevanceRank == cursor.RelevanceRank &&
+             string.Compare(candidate.NormalizedUsername, cursor.NormalizedUsername) > 0) ||
+            (candidate.RelevanceRank == cursor.RelevanceRank &&
+             candidate.NormalizedUsername == cursor.NormalizedUsername &&
+             string.Compare(candidate.StableId, cursor.StableId) > 0));
+    }
+
+    private static UserSearchResultDTO ToUserSearchResult(UserSearchCandidate candidate)
+    {
+        return new UserSearchResultDTO
+        {
+            Id = candidate.Id,
+            Type = "user",
+            Username = candidate.Username,
+            DisplayLabel = candidate.Username,
+            SupportingText = "User"
+        };
     }
 
     public async Task<GetUserDTO> UpdateCurrentUserAsync(string auth0UserId, UpdateUserProfileRequest request)
@@ -329,6 +420,60 @@ public class UserService : IUserService
     {
         return exception.InnerException?.Message.Contains("IX_Users_NormalizedUsername", StringComparison.OrdinalIgnoreCase) == true;
     }
+
+    private static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal);
+    }
+
+    private static string BuildUserSearchCursor(string normalizedQuery, UserSearchCandidate candidate)
+    {
+        var payload = new UserSearchCursor(normalizedQuery, candidate.RelevanceRank, candidate.NormalizedUsername, candidate.StableId);
+        return Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(payload));
+    }
+
+    private static UserSearchCursor? DecodeUserSearchCursor(string? cursor, string normalizedQuery)
+    {
+        if (string.IsNullOrWhiteSpace(cursor))
+            return null;
+
+        if (cursor.Length > SearchRequestLimits.MaximumCursorLength)
+            throw new ValidationException("Cursor is invalid.");
+
+        try
+        {
+            var payload = JsonSerializer.Deserialize<UserSearchCursor>(Convert.FromBase64String(cursor));
+            if (payload is null ||
+                string.IsNullOrEmpty(payload.Query) ||
+                payload.RelevanceRank is < 0 or > 2 ||
+                string.IsNullOrEmpty(payload.NormalizedUsername) ||
+                !Guid.TryParse(payload.StableId, out _))
+                throw new ValidationException("Cursor is invalid.");
+
+            if (!string.Equals(payload.Query, normalizedQuery, StringComparison.Ordinal))
+                throw new ValidationException("Cursor does not match query.");
+
+            return payload;
+        }
+        catch (Exception exception) when (exception is FormatException or JsonException)
+        {
+            throw new ValidationException("Cursor is invalid.");
+        }
+    }
+
+    private sealed class UserSearchCandidate
+    {
+        public Guid Id { get; init; }
+        public int RelevanceRank { get; init; }
+        public required string NormalizedUsername { get; init; }
+        public required string Username { get; init; }
+        public required string StableId { get; init; }
+    }
+
+    private sealed record UserSearchCursor(string Query, int RelevanceRank, string NormalizedUsername, string StableId);
 
     private static void EnsureActive(User user)
     {

--- a/src/MercuriusAPI/Services/UserServices/UserService.cs
+++ b/src/MercuriusAPI/Services/UserServices/UserService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Mercurius.LAN.API.Data;
 using Mercurius.LAN.API.DTOs.Auth;
 using Mercurius.LAN.API.Exceptions;
@@ -102,14 +101,13 @@ public class UserService : IUserService
         int pageSize,
         CancellationToken cancellationToken = default)
     {
-        var normalizedQuery = (query ?? string.Empty).Trim().ToLowerInvariant();
-        if (normalizedQuery.Length > SearchRequestLimits.MaximumQueryLength)
-            throw new ValidationException($"Query cannot exceed {SearchRequestLimits.MaximumQueryLength} characters.");
+        var normalizedQuery = SearchRequest.NormalizeQuery(query);
+        SearchRequest.ValidateQueryLength(normalizedQuery);
 
         if (normalizedQuery.Length < SearchRequestLimits.MinimumQueryLength)
             return new UserSearchResponseDTO { Results = [], HasMore = false };
 
-        var boundedPageSize = Math.Clamp(pageSize, 1, SearchRequestLimits.MaximumPageSize);
+        var boundedPageSize = SearchRequest.BoundPageSize(pageSize);
         var decodedCursor = DecodeUserSearchCursor(cursor, normalizedQuery);
         var users = await BuildPagedUserSearchQuery(normalizedQuery, decodedCursor, boundedPageSize + 1)
             .ToListAsync(cancellationToken);
@@ -131,14 +129,15 @@ public class UserService : IUserService
         return ApplyUserSearchCursor(BuildUserSearchQuery(normalizedQuery), cursor)
             .OrderBy(user => user.RelevanceRank)
             .ThenBy(user => user.NormalizedUsername)
-            .ThenBy(user => user.StableId)
+            .ThenBy(user => user.Id)
             .Take(limit);
     }
 
     private IQueryable<UserSearchCandidate> BuildUserSearchQuery(string normalizedQuery)
     {
-        var containsPattern = $"%{EscapeLikePattern(normalizedQuery)}%";
-        var prefixPattern = $"{EscapeLikePattern(normalizedQuery)}%";
+        var escapedQuery = SearchRequest.EscapeLikePattern(normalizedQuery);
+        var containsPattern = $"%{escapedQuery}%";
+        var prefixPattern = $"{escapedQuery}%";
 
         return _dbContext.Users
             .AsNoTracking()
@@ -154,8 +153,7 @@ public class UserService : IUserService
                     ? 0
                     : EF.Functions.Like(user.NormalizedUsername, prefixPattern, "\\") ? 1 : 2,
                 NormalizedUsername = user.NormalizedUsername!,
-                Username = user.Username!,
-                StableId = user.Id.ToString()
+                Username = user.Username!
             });
     }
 
@@ -170,7 +168,7 @@ public class UserService : IUserService
              string.Compare(candidate.NormalizedUsername, cursor.NormalizedUsername) > 0) ||
             (candidate.RelevanceRank == cursor.RelevanceRank &&
              candidate.NormalizedUsername == cursor.NormalizedUsername &&
-             string.Compare(candidate.StableId, cursor.StableId) > 0));
+             candidate.Id.CompareTo(cursor.StableId) > 0));
     }
 
     private static UserSearchResultDTO ToUserSearchResult(UserSearchCandidate candidate)
@@ -421,47 +419,23 @@ public class UserService : IUserService
         return exception.InnerException?.Message.Contains("IX_Users_NormalizedUsername", StringComparison.OrdinalIgnoreCase) == true;
     }
 
-    private static string EscapeLikePattern(string value)
-    {
-        return value
-            .Replace("\\", "\\\\", StringComparison.Ordinal)
-            .Replace("%", "\\%", StringComparison.Ordinal)
-            .Replace("_", "\\_", StringComparison.Ordinal);
-    }
-
     private static string BuildUserSearchCursor(string normalizedQuery, UserSearchCandidate candidate)
     {
-        var payload = new UserSearchCursor(normalizedQuery, candidate.RelevanceRank, candidate.NormalizedUsername, candidate.StableId);
-        return Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var payload = new UserSearchCursor(normalizedQuery, candidate.RelevanceRank, candidate.NormalizedUsername, candidate.Id);
+        return SearchCursorCodec.Encode(payload);
     }
 
     private static UserSearchCursor? DecodeUserSearchCursor(string? cursor, string normalizedQuery)
     {
-        if (string.IsNullOrWhiteSpace(cursor))
-            return null;
-
-        if (cursor.Length > SearchRequestLimits.MaximumCursorLength)
-            throw new ValidationException("Cursor is invalid.");
-
-        try
-        {
-            var payload = JsonSerializer.Deserialize<UserSearchCursor>(Convert.FromBase64String(cursor));
-            if (payload is null ||
-                string.IsNullOrEmpty(payload.Query) ||
-                payload.RelevanceRank is < 0 or > 2 ||
-                string.IsNullOrEmpty(payload.NormalizedUsername) ||
-                !Guid.TryParse(payload.StableId, out _))
-                throw new ValidationException("Cursor is invalid.");
-
-            if (!string.Equals(payload.Query, normalizedQuery, StringComparison.Ordinal))
-                throw new ValidationException("Cursor does not match query.");
-
-            return payload;
-        }
-        catch (Exception exception) when (exception is FormatException or JsonException)
-        {
-            throw new ValidationException("Cursor is invalid.");
-        }
+        return SearchCursorCodec.Decode<UserSearchCursor>(
+            cursor,
+            normalizedQuery,
+            payload =>
+                !string.IsNullOrEmpty(payload.Query) &&
+                payload.RelevanceRank is >= 0 and <= 2 &&
+                !string.IsNullOrEmpty(payload.NormalizedUsername) &&
+                payload.StableId != Guid.Empty,
+            payload => payload.Query);
     }
 
     private sealed class UserSearchCandidate
@@ -470,10 +444,9 @@ public class UserService : IUserService
         public int RelevanceRank { get; init; }
         public required string NormalizedUsername { get; init; }
         public required string Username { get; init; }
-        public required string StableId { get; init; }
     }
 
-    private sealed record UserSearchCursor(string Query, int RelevanceRank, string NormalizedUsername, string StableId);
+    private sealed record UserSearchCursor(string Query, int RelevanceRank, string NormalizedUsername, Guid StableId);
 
     private static void EnsureActive(User user)
     {

--- a/src/MercuriusAPI/Services/UserServices/UserValidationService.cs
+++ b/src/MercuriusAPI/Services/UserServices/UserValidationService.cs
@@ -58,12 +58,9 @@ public class UserValidationService : IUserService
         int pageSize,
         CancellationToken cancellationToken = default)
     {
-        var normalizedQuery = (query ?? string.Empty).Trim();
-        if (normalizedQuery.Length > SearchRequestLimits.MaximumQueryLength)
-            throw new ValidationException($"Query cannot exceed {SearchRequestLimits.MaximumQueryLength} characters.");
-
-        if (pageSize <= 0)
-            throw new ValidationException("pageSize must be greater than 0.");
+        var normalizedQuery = SearchRequest.NormalizeQuery(query);
+        SearchRequest.ValidateQueryLength(normalizedQuery);
+        SearchRequest.ValidatePageSize(pageSize);
 
         return _inner.SearchUsersAsync(normalizedQuery, cursor, pageSize, cancellationToken);
     }

--- a/src/MercuriusAPI/Services/UserServices/UserValidationService.cs
+++ b/src/MercuriusAPI/Services/UserServices/UserValidationService.cs
@@ -1,5 +1,6 @@
 using Mercurius.LAN.API.DTOs.Auth;
 using Mercurius.LAN.API.Exceptions;
+using Mercurius.LAN.API.Services.SearchServices;
 
 namespace Mercurius.LAN.API.Services.UserServices;
 
@@ -49,6 +50,22 @@ public class UserValidationService : IUserService
             throw new ValidationException("Username must be 3-32 alphanumeric characters.");
 
         return _inner.GetPublicUserProfileByUsernameAsync(normalizedUsername);
+    }
+
+    public Task<UserSearchResponseDTO> SearchUsersAsync(
+        string? query,
+        string? cursor,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedQuery = (query ?? string.Empty).Trim();
+        if (normalizedQuery.Length > SearchRequestLimits.MaximumQueryLength)
+            throw new ValidationException($"Query cannot exceed {SearchRequestLimits.MaximumQueryLength} characters.");
+
+        if (pageSize <= 0)
+            throw new ValidationException("pageSize must be greater than 0.");
+
+        return _inner.SearchUsersAsync(normalizedQuery, cursor, pageSize, cancellationToken);
     }
 
     public Task<GetUserDTO> UpdateCurrentUserAsync(string auth0UserId, UpdateUserProfileRequest request)

--- a/tests/MercuriusAPI.Tests/UserEndpointRouteTests.cs
+++ b/tests/MercuriusAPI.Tests/UserEndpointRouteTests.cs
@@ -31,6 +31,15 @@ public class UserEndpointRouteTests
     }
 
     [Fact]
+    public void UserCollectionRoute_RequiresAuthorization()
+    {
+        var endpoint = GetUserRouteEndpoint("GET", "v{version:apiVersion}/lan/users/");
+
+        Assert.DoesNotContain(endpoint.Metadata, metadata => metadata is IAllowAnonymous);
+        Assert.Contains(endpoint.Metadata, metadata => metadata is IAuthorizeData);
+    }
+
+    [Fact]
     public void GuidAndUsernameDeleteRoutes_HaveDistinctRoutePatterns()
     {
         var endpoints = GetUserRouteEndpoints("DELETE").ToList();

--- a/tests/MercuriusAPI.Tests/UserEndpointRouteTests.cs
+++ b/tests/MercuriusAPI.Tests/UserEndpointRouteTests.cs
@@ -1,4 +1,5 @@
 using Mercurius.LAN.API.Endpoints;
+using Mercurius.LAN.API.Extensions;
 using Mercurius.LAN.API.Services.UserServices;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -37,6 +38,18 @@ public class UserEndpointRouteTests
 
         Assert.DoesNotContain(endpoint.Metadata, metadata => metadata is IAllowAnonymous);
         Assert.Contains(endpoint.Metadata, metadata => metadata is IAuthorizeData);
+    }
+
+    [Fact]
+    public void UserCollectionRoute_UsesAuthenticatedSearchRateLimitPolicy()
+    {
+        var endpoint = GetUserRouteEndpoint("GET", "v{version:apiVersion}/lan/users/");
+
+        var rateLimitMetadata = Assert.Single(endpoint.Metadata.Where(metadata =>
+            metadata.GetType().GetProperty("PolicyName")?.GetValue(metadata) is not null));
+        var policyName = rateLimitMetadata.GetType().GetProperty("PolicyName")!.GetValue(rateLimitMetadata);
+
+        Assert.Equal(RateLimitPolicies.AuthenticatedSearch, policyName);
     }
 
     [Fact]

--- a/tests/MercuriusAPI.Tests/UserSearchIndexMigrationTests.cs
+++ b/tests/MercuriusAPI.Tests/UserSearchIndexMigrationTests.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using Mercurius.LAN.API.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+
+namespace Mercurius.LAN.API.Tests;
+
+public class UserSearchIndexMigrationTests
+{
+    [Fact]
+    public void AuthenticatedUserSearchIndexes_CreatesRequiredIndexes()
+    {
+        var operations = GetMigrationOperations("Up");
+        var sql = string.Join("\n", operations.OfType<SqlOperation>().Select(operation => operation.Sql));
+
+        Assert.Contains("CREATE EXTENSION IF NOT EXISTS pg_trgm", sql);
+        Assert.Contains("CREATE INDEX \"IX_Users_AuthenticatedSearch_NormalizedUsername_Trgm\"", sql);
+        Assert.Contains("ON \"Users\" USING gin (\"NormalizedUsername\" gin_trgm_ops)", sql);
+        Assert.Contains("CREATE INDEX \"IX_Users_AuthenticatedSearch_Cursor\"", sql);
+        Assert.Contains("ON \"Users\" (\"NormalizedUsername\", \"Id\")", sql);
+        Assert.Contains("AND \"IsDeleted\" = false", sql);
+        Assert.Contains("\"Username\" <> ''", sql);
+        Assert.Contains("\"NormalizedUsername\" <> ''", sql);
+        Assert.DoesNotContain("\"Firstname\"", sql);
+        Assert.DoesNotContain("\"Lastname\"", sql);
+    }
+
+    [Fact]
+    public void AuthenticatedUserSearchIndexes_DropsRequiredIndexes()
+    {
+        var operations = GetMigrationOperations("Down");
+        var sql = string.Join("\n", operations.OfType<SqlOperation>().Select(operation => operation.Sql));
+
+        Assert.Contains("DROP INDEX \"IX_Users_AuthenticatedSearch_Cursor\"", sql);
+        Assert.Contains("DROP INDEX \"IX_Users_AuthenticatedSearch_NormalizedUsername_Trgm\"", sql);
+    }
+
+    private static IReadOnlyList<MigrationOperation> GetMigrationOperations(string methodName)
+    {
+        var migration = new AuthenticatedUserSearchIndexes();
+        var migrationBuilder = new MigrationBuilder("Npgsql.EntityFrameworkCore.PostgreSQL");
+
+        typeof(AuthenticatedUserSearchIndexes)
+            .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(migration, [migrationBuilder]);
+
+        return migrationBuilder.Operations;
+    }
+}

--- a/tests/MercuriusAPI.Tests/UserTests.cs
+++ b/tests/MercuriusAPI.Tests/UserTests.cs
@@ -6,6 +6,7 @@ using Mercurius.LAN.API.Services.SearchServices;
 using Mercurius.LAN.API.Services.Auth0;
 using Mercurius.LAN.API.Services.UserServices;
 using Microsoft.EntityFrameworkCore;
+using System.Reflection;
 using System.Text.Json;
 
 namespace Mercurius.LAN.API.Tests;
@@ -340,7 +341,7 @@ public class UserTests
     }
 
     [Fact]
-    public async Task SearchUsersAsync_ForwardsTrimmedQueryCursorAndPageSize()
+    public async Task SearchUsersAsync_ForwardsNormalizedQueryCursorAndPageSize()
     {
         var inner = new RecordingUserService();
         var service = new UserValidationService(inner);
@@ -348,7 +349,7 @@ public class UserTests
         var result = await service.SearchUsersAsync(" Alpha ", "cursor-1", 7);
 
         Assert.Same(inner.UserSearchResponse, result);
-        Assert.Equal("Alpha", inner.LastUserSearchQuery);
+        Assert.Equal("alpha", inner.LastUserSearchQuery);
         Assert.Equal("cursor-1", inner.LastUserSearchCursor);
         Assert.Equal(7, inner.LastUserSearchPageSize);
     }
@@ -652,6 +653,34 @@ public class UserTests
         Assert.False(page2.HasMore);
         Assert.Null(page2.NextCursor);
         Assert.Equal(["Alpha", "Alphaa", "Alphab"], page1.Results.Concat(page2.Results).Select(result => result.Username));
+    }
+
+    [Fact]
+    public void SearchUsersAsync_QueryAndKeysetCursor_TranslateForPostgreSql()
+    {
+        var options = new DbContextOptionsBuilder<MercuriusDBContext>()
+            .UseNpgsql("Host=localhost;Database=translation-only")
+            .Options;
+        using var dbContext = new MercuriusDBContext(options);
+        var service = new UserService(
+            dbContext,
+            new RecordingAuth0ManagementService(new Auth0ProfileSnapshot("public@example.com", true, true)));
+
+        var buildQuery = typeof(UserService).GetMethod("BuildPagedUserSearchQuery", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var cursorType = typeof(UserService).GetNestedType("UserSearchCursor", BindingFlags.NonPublic)!;
+        var cursorId = Guid.NewGuid();
+
+        var cursor = Activator.CreateInstance(cursorType, "alpha", 1, "alphab", cursorId)!;
+        var query = (IQueryable)buildQuery.Invoke(service, ["alpha", cursor, 3])!;
+        var sql = query.ToQueryString();
+
+        Assert.Contains("LIKE", sql);
+        Assert.Contains("\"NormalizedUsername\"", sql);
+        Assert.Contains("\"Id\"", sql);
+        Assert.Contains("ORDER BY", sql);
+        Assert.Contains("LIMIT", sql);
+        Assert.DoesNotContain("CAST", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("::text", sql, StringComparison.OrdinalIgnoreCase);
     }
 
     private static MercuriusDBContext CreateDbContext()

--- a/tests/MercuriusAPI.Tests/UserTests.cs
+++ b/tests/MercuriusAPI.Tests/UserTests.cs
@@ -2,9 +2,11 @@ using Mercurius.LAN.API.DTOs.Auth;
 using Mercurius.LAN.API.Data;
 using Mercurius.LAN.API.Exceptions;
 using Mercurius.LAN.API.Models;
+using Mercurius.LAN.API.Services.SearchServices;
 using Mercurius.LAN.API.Services.Auth0;
 using Mercurius.LAN.API.Services.UserServices;
 using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
 
 namespace Mercurius.LAN.API.Tests;
 
@@ -100,6 +102,32 @@ public class UserTests
         Assert.DoesNotContain("EmailVerified", properties);
         Assert.DoesNotContain("Auth0UserId", properties);
         Assert.DoesNotContain("IsDeleted", properties);
+        Assert.DoesNotContain("CreatedAtUtc", properties);
+        Assert.DoesNotContain("UpdatedAtUtc", properties);
+    }
+
+    [Fact]
+    public void UserSearchResultDTO_DoesNotExposePrivateFields()
+    {
+        var properties = typeof(UserSearchResultDTO)
+            .GetProperties()
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Contains("Id", properties);
+        Assert.Contains("Type", properties);
+        Assert.Contains("Username", properties);
+        Assert.Contains("DisplayLabel", properties);
+        Assert.Contains("SupportingText", properties);
+        Assert.DoesNotContain("Email", properties);
+        Assert.DoesNotContain("EmailVerified", properties);
+        Assert.DoesNotContain("Auth0UserId", properties);
+        Assert.DoesNotContain("IsDeleted", properties);
+        Assert.DoesNotContain("Firstname", properties);
+        Assert.DoesNotContain("Lastname", properties);
+        Assert.DoesNotContain("DiscordId", properties);
+        Assert.DoesNotContain("SteamId", properties);
+        Assert.DoesNotContain("RiotId", properties);
         Assert.DoesNotContain("CreatedAtUtc", properties);
         Assert.DoesNotContain("UpdatedAtUtc", properties);
     }
@@ -312,6 +340,32 @@ public class UserTests
     }
 
     [Fact]
+    public async Task SearchUsersAsync_ForwardsTrimmedQueryCursorAndPageSize()
+    {
+        var inner = new RecordingUserService();
+        var service = new UserValidationService(inner);
+
+        var result = await service.SearchUsersAsync(" Alpha ", "cursor-1", 7);
+
+        Assert.Same(inner.UserSearchResponse, result);
+        Assert.Equal("Alpha", inner.LastUserSearchQuery);
+        Assert.Equal("cursor-1", inner.LastUserSearchCursor);
+        Assert.Equal(7, inner.LastUserSearchPageSize);
+    }
+
+    [Fact]
+    public async Task SearchUsersAsync_RejectsOverlongQuery()
+    {
+        var service = new UserValidationService(new RecordingUserService());
+        var query = new string('a', SearchRequestLimits.MaximumQueryLength + 1);
+
+        var exception = await Assert.ThrowsAsync<ValidationException>(() =>
+            service.SearchUsersAsync(query, cursor: null, pageSize: 10));
+
+        Assert.Contains($"Query cannot exceed {SearchRequestLimits.MaximumQueryLength} characters.", exception.Message);
+    }
+
+    [Fact]
     public async Task DeleteUserByIdAsync_RejectsEmptyIds()
     {
         var service = new UserValidationService(new RecordingUserService());
@@ -487,6 +541,119 @@ public class UserTests
             service.GetPublicUserProfileByUsernameAsync("playerone"));
     }
 
+    [Fact]
+    public async Task SearchUsersAsync_ReturnsBoundedPrivacySafeMatches_InDeterministicOrder()
+    {
+        await using var dbContext = CreateDbContext();
+        var exact = CreateStoredUser("auth0|exact", "exact@example.com", "Alpha");
+        var prefix = CreateStoredUser("auth0|prefix", "prefix@example.com", "AlphaBeta");
+        var contains = CreateStoredUser("auth0|contains", "contains@example.com", "BetaAlpha");
+        var deleted = CreateStoredUser("auth0|deleted", "deleted@example.com", "AlphaDeleted");
+        deleted.Anonymize(DateTime.UtcNow);
+        var missingUsername = CreateStoredUser("auth0|missing-username", "missing-username@example.com", "AlphaMissing");
+        missingUsername.Username = null;
+        var missingNormalizedUsername = CreateStoredUser("auth0|missing-normalized", "missing-normalized@example.com", "AlphaMissingNormalized");
+        missingNormalizedUsername.NormalizedUsername = null;
+        dbContext.Users.AddRange(contains, prefix, exact, deleted, missingUsername, missingNormalizedUsername);
+        await dbContext.SaveChangesAsync();
+
+        var service = new UserService(
+            dbContext,
+            new RecordingAuth0ManagementService(new Auth0ProfileSnapshot("public@example.com", true, true)));
+
+        var response = await service.SearchUsersAsync("  ALPHA  ", cursor: null, pageSize: 2);
+
+        Assert.True(response.HasMore);
+        Assert.NotNull(response.NextCursor);
+        Assert.Collection(response.Results,
+            first =>
+            {
+                Assert.Equal(exact.Id, first.Id);
+                Assert.Equal("user", first.Type);
+                Assert.Equal("Alpha", first.Username);
+                Assert.Equal("Alpha", first.DisplayLabel);
+                Assert.Equal("User", first.SupportingText);
+            },
+            second =>
+            {
+                Assert.Equal(prefix.Id, second.Id);
+                Assert.Equal("AlphaBeta", second.Username);
+            });
+
+        var json = JsonSerializer.Serialize(response, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        Assert.Contains("\"results\"", json);
+        Assert.Contains("\"nextCursor\"", json);
+        Assert.Contains("\"hasMore\"", json);
+        Assert.DoesNotContain("email", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("auth0", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("deleted", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("firstname", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("lastname", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SearchUsersAsync_DoesNotRequireFirstOrLastName()
+    {
+        await using var dbContext = CreateDbContext();
+        var user = CreateStoredUser("auth0|username-only", "username-only@example.com", "UsernameOnly");
+        user.Firstname = null;
+        user.Lastname = null;
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        var service = new UserService(
+            dbContext,
+            new RecordingAuth0ManagementService(new Auth0ProfileSnapshot("public@example.com", true, true)));
+
+        var response = await service.SearchUsersAsync("username", cursor: null, pageSize: 10);
+
+        var result = Assert.Single(response.Results);
+        Assert.Equal(user.Id, result.Id);
+        Assert.Equal("UsernameOnly", result.Username);
+    }
+
+    [Fact]
+    public async Task SearchUsersAsync_ReturnsEmptyResults_ForShortQueries()
+    {
+        await using var dbContext = CreateDbContext();
+        dbContext.Users.Add(CreateStoredUser("auth0|short", "short@example.com", "Alpha"));
+        await dbContext.SaveChangesAsync();
+
+        var service = new UserService(
+            dbContext,
+            new RecordingAuth0ManagementService(new Auth0ProfileSnapshot("public@example.com", true, true)));
+
+        var response = await service.SearchUsersAsync("al", cursor: null, pageSize: 10);
+
+        Assert.Empty(response.Results);
+        Assert.False(response.HasMore);
+        Assert.Null(response.NextCursor);
+    }
+
+    [Fact]
+    public async Task SearchUsersAsync_SupportsCursorContinuation()
+    {
+        await using var dbContext = CreateDbContext();
+        dbContext.Users.AddRange(
+            CreateStoredUser("auth0|alpha", "alpha@example.com", "Alpha"),
+            CreateStoredUser("auth0|alphaa", "alphaa@example.com", "Alphaa"),
+            CreateStoredUser("auth0|alphab", "alphab@example.com", "Alphab"));
+        await dbContext.SaveChangesAsync();
+
+        var service = new UserService(
+            dbContext,
+            new RecordingAuth0ManagementService(new Auth0ProfileSnapshot("public@example.com", true, true)));
+
+        var page1 = await service.SearchUsersAsync("alpha", cursor: null, pageSize: 2);
+        var page2 = await service.SearchUsersAsync("alpha", page1.NextCursor, pageSize: 2);
+
+        Assert.True(page1.HasMore);
+        Assert.NotNull(page1.NextCursor);
+        Assert.False(page2.HasMore);
+        Assert.Null(page2.NextCursor);
+        Assert.Equal(["Alpha", "Alphaa", "Alphab"], page1.Results.Concat(page2.Results).Select(result => result.Username));
+    }
+
     private static MercuriusDBContext CreateDbContext()
     {
         var options = new DbContextOptionsBuilder<MercuriusDBContext>()
@@ -496,15 +663,15 @@ public class UserTests
         return new MercuriusDBContext(options);
     }
 
-    private static User CreateStoredUser(string auth0UserId, string email)
+    private static User CreateStoredUser(string auth0UserId, string email, string username = "PlayerOne")
     {
         var now = DateTime.UtcNow;
         return new User
         {
             Id = Guid.NewGuid(),
             Auth0UserId = auth0UserId,
-            Username = "PlayerOne",
-            NormalizedUsername = "playerone",
+            Username = username,
+            NormalizedUsername = username.ToLowerInvariant(),
             Firstname = "Player",
             Lastname = "One",
             Email = email,
@@ -522,6 +689,9 @@ public class UserTests
         public string? LastUpdateCurrentSubject { get; private set; }
         public UpdateUserProfileRequest? LastUpdateCurrentRequest { get; private set; }
         public string? LastPublicProfileUsername { get; private set; }
+        public string? LastUserSearchQuery { get; private set; }
+        public string? LastUserSearchCursor { get; private set; }
+        public int LastUserSearchPageSize { get; private set; }
         public GetUserDTO CreatedUser { get; } = new(new User
         {
             Id = Guid.NewGuid(),
@@ -541,6 +711,33 @@ public class UserTests
             SteamId = "steam-2",
             RiotId = "riot-2"
         };
+        public UserSearchResponseDTO UserSearchResponse { get; } = new()
+        {
+            Results =
+            [
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Type = "user",
+                    Username = "ValidUser",
+                    DisplayLabel = "ValidUser",
+                    SupportingText = "User"
+                }
+            ],
+            HasMore = false
+        };
+
+        public Task<UserSearchResponseDTO> SearchUsersAsync(
+            string? query,
+            string? cursor,
+            int pageSize,
+            CancellationToken cancellationToken = default)
+        {
+            LastUserSearchQuery = query;
+            LastUserSearchCursor = cursor;
+            LastUserSearchPageSize = pageSize;
+            return Task.FromResult(UserSearchResponse);
+        }
 
         public Task<GetUserDTO> CreateUserAsync(CreateUserProfileRequest request)
         {


### PR DESCRIPTION
## Summary
- Add OpenSpec change artifacts for authenticated user search and related user-owned team management constraints.
- Add authenticated user search response/result DTOs and search request/cursor support.
- Update user/search endpoints, search and user services, validation, and rate limiting for authenticated user lookup behavior.
- Add EF migration for authenticated user search indexes.
- Add and extend tests covering user search behavior, endpoint routing, and migration indexes.

## Testing
- Not run by me; please verify CI results on the pull request.