### PR TITLE
Split current-user profile read and write routes

### DIFF
--- a/openspec/changes/split-current-user-profile-writes/.openspec.yaml
+++ b/openspec/changes/split-current-user-profile-writes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-12

--- a/openspec/changes/split-current-user-profile-writes/design.md
+++ b/openspec/changes/split-current-user-profile-writes/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The current-user profile flow is Auth0-backed. The API extracts the current Auth0 subject from the authenticated principal, stores that subject on `User.Auth0UserId`, and keeps local profile fields such as username, first name, last name, and platform IDs in the Mercurius database. `GET /v1/lan/users/me` currently uses a helper that fetches Auth0 profile metadata, creates a database row when none exists, and updates stored email verification snapshots for existing users.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `GET /me` read-only at the service layer.
+- Provide an explicit authenticated create route at `PUT /me`.
+- Preserve `PATCH /me` as an update-only route for existing current-user rows.
+- Preserve `POST /me/complete-profile` as an update-only compatibility route for existing incomplete current-user rows.
+- Keep existing DTO shapes for current-user profile responses and profile write requests.
+
+**Non-Goals:**
+- Changing the `User` table schema or adding migrations.
+- Changing public user profile behavior.
+- Changing Auth0 JWT validation, role mapping, or CORS configuration.
+
+## Decisions
+
+- Use a new `CreateCurrentUserAsync(auth0UserId, request)` service method for `PUT /me`.
+  - Rationale: current-user creation uses the authenticated subject, not a client-supplied Auth0 ID, while admin creation still uses `CreateUserProfileRequest`.
+  - Alternative considered: reuse admin `CreateUserAsync`; rejected because it trusts a payload Auth0 ID and is scoped to admin operations.
+
+- Make `GetCurrentUserAsync` use the existing required-user lookup and skip Auth0 Management API synchronization.
+  - Rationale: the endpoint must not create or update database objects, and refreshing stored email snapshots is a write.
+  - Alternative considered: keep email snapshot refresh on read; rejected because it violates safe read semantics.
+
+- Treat `PUT /me` against an existing profile as a validation error.
+  - Rationale: the requested split assigns creation to PUT and updates to PATCH, so existing profiles should use PATCH.
+  - Alternative considered: make PUT idempotently replace the full profile; rejected because the requested behavior says PUT is for the missing-user case.
+
+- Keep `POST /me/complete-profile` separate from `CreateCurrentUserAsync`.
+  - Rationale: legacy complete-profile clients call this route after a local user row exists, so it should complete/update that row instead of trying to create it.
+  - Alternative considered: route it to `PUT /me`; rejected because that fails for existing users and duplicates create semantics.
+
+## Risks / Trade-offs
+
+- Existing clients that relied on `GET /me` to bootstrap a profile will now receive 404 until they call `PUT /me` with profile data. Mitigation: keep the response DTO shape unchanged and add explicit route/test coverage for the new create path.
+- Stored Auth0 email snapshots will no longer refresh on every current-user read. Mitigation: write-oriented flows such as password reset can still refresh Auth0 profile data where needed.

--- a/openspec/changes/split-current-user-profile-writes/proposal.md
+++ b/openspec/changes/split-current-user-profile-writes/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`GET /v1/lan/users/me` currently creates missing current-user rows and refreshes stored Auth0 profile snapshots. Read endpoints should be safe to call without mutating database state, and current-user creation/update behavior should be explicit.
+
+## What Changes
+
+- Change `GET /v1/lan/users/me` to return the existing active current-user profile only.
+- Add `PUT /v1/lan/users/me` to create the current-user profile when it does not already exist.
+- Keep `PATCH /v1/lan/users/me` as the update path for an existing current-user profile.
+- Keep `POST /v1/lan/users/me/complete-profile` as a compatibility update path for an existing current-user profile.
+- Make missing-profile behavior explicit: `GET` and `PATCH` return not found when the current user row does not exist.
+- Prevent current-user creation from overwriting an existing user row.
+
+## Capabilities
+
+### New Capabilities
+- `current-user-profile`: Authenticated current-user profile lookup, creation, and update semantics.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- `UserEndpoints` route mapping for authenticated current-user profile routes.
+- `IUserService`, `UserService`, and `UserValidationService` current-user profile methods.
+- Tests under `tests/MercuriusAPI.Tests` for route registration, read/write separation, not found behavior, and create/update boundaries.
+- No database schema, migration, CORS, Auth0 configuration, environment variable, or deployment configuration changes are expected.

--- a/openspec/changes/split-current-user-profile-writes/specs/current-user-profile/spec.md
+++ b/openspec/changes/split-current-user-profile-writes/specs/current-user-profile/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Current user profile read
+The API MUST expose an authenticated `GET /v1/lan/users/me` endpoint that reads the active profile for the authenticated Auth0 subject without creating or updating database records.
+
+#### Scenario: Existing current user returned
+- **WHEN** an authenticated client requests `GET /v1/lan/users/me` and an active user exists for the token subject
+- **THEN** the API returns the current profile response for that user
+
+#### Scenario: Missing current user is not created
+- **WHEN** an authenticated client requests `GET /v1/lan/users/me` and no user exists for the token subject
+- **THEN** the API returns 404
+- **AND** no user record is created
+
+#### Scenario: Current user read does not refresh snapshots
+- **WHEN** an authenticated client requests `GET /v1/lan/users/me` for an existing active user
+- **THEN** the API MUST NOT update stored Auth0 email or verification snapshots as part of the read
+
+### Requirement: Current user profile creation
+The API MUST expose an authenticated `PUT /v1/lan/users/me` endpoint that creates the profile for the authenticated Auth0 subject when no user record exists.
+
+#### Scenario: Missing current user is created
+- **WHEN** an authenticated client requests `PUT /v1/lan/users/me` with a valid profile payload and no user exists for the token subject
+- **THEN** the API creates a user linked to that Auth0 subject
+- **AND** the API returns the created user profile
+
+#### Scenario: Existing current user is not recreated
+- **WHEN** an authenticated client requests `PUT /v1/lan/users/me` and a user already exists for the token subject
+- **THEN** the API rejects the request
+- **AND** the existing user profile is not overwritten
+
+### Requirement: Current user profile update
+The API MUST expose authenticated current-user profile update endpoints that update an existing active profile for the authenticated Auth0 subject.
+
+#### Scenario: Existing current user is updated
+- **WHEN** an authenticated client requests `PATCH /v1/lan/users/me` with a valid profile payload and an active user exists for the token subject
+- **THEN** the API updates the local profile fields for that user
+
+#### Scenario: Missing current user is not created by update
+- **WHEN** an authenticated client requests `PATCH /v1/lan/users/me` and no user exists for the token subject
+- **THEN** the API returns 404
+- **AND** no user record is created
+
+#### Scenario: Existing current user is completed through compatibility route
+- **WHEN** an authenticated client requests `POST /v1/lan/users/me/complete-profile` with a valid profile payload and an active user exists for the token subject
+- **THEN** the API updates the local profile fields for that user
+- **AND** the API MUST NOT try to create a new user
+
+#### Scenario: Missing current user is not created by compatibility route
+- **WHEN** an authenticated client requests `POST /v1/lan/users/me/complete-profile` and no user exists for the token subject
+- **THEN** the API returns 404
+- **AND** no user record is created

--- a/openspec/changes/split-current-user-profile-writes/tasks.md
+++ b/openspec/changes/split-current-user-profile-writes/tasks.md
@@ -1,0 +1,21 @@
+## 1. Current User API Contract
+
+- [x] 1.1 Add `PUT /v1/lan/users/me` and keep it authenticated.
+- [x] 1.2 Change `GET /v1/lan/users/me` so it only reads existing current-user records.
+- [x] 1.3 Keep `PATCH /v1/lan/users/me` update-only for existing current-user records.
+- [x] 1.4 Keep `POST /v1/lan/users/me/complete-profile` update-only for existing current-user records.
+
+## 2. Service Behavior
+
+- [x] 2.1 Add a current-user creation service method that derives Auth0 identity from the authenticated subject.
+- [x] 2.2 Ensure current-user reads do not create users, call Auth0 profile sync, or save database changes.
+- [x] 2.3 Ensure current-user creation rejects existing users and current-user update rejects missing users.
+- [x] 2.4 Ensure complete-profile updates existing users and rejects missing users.
+
+## 3. Regression Coverage
+
+- [x] 3.1 Add tests for read-only `GET /me`, missing-user 404 behavior, and absence of database writes.
+- [x] 3.2 Add tests for `PUT /me` creation and existing-user rejection.
+- [x] 3.3 Add route tests for authenticated `PUT /me`.
+- [x] 3.4 Add tests for `POST /me/complete-profile` updating existing users and not creating missing users.
+- [x] 3.5 Run `dotnet test LAN.API.sln`.

--- a/src/MercuriusAPI/Endpoints/UserEndpoints.cs
+++ b/src/MercuriusAPI/Endpoints/UserEndpoints.cs
@@ -39,6 +39,12 @@ public static class UserEndpoints
         })
         .RequireAuthorization();
 
+        group.MapPut("/me", async (CompleteUserProfileRequest request, ClaimsPrincipal user, IUserService userService) =>
+        {
+            return await userService.CreateCurrentUserAsync(GetAuth0UserId(user), request);
+        })
+        .RequireAuthorization();
+
         group.MapPatch("/me", async (UpdateUserProfileRequest request, ClaimsPrincipal user, IUserService userService) =>
         {
             return await userService.UpdateCurrentUserAsync(GetAuth0UserId(user), request);

--- a/src/MercuriusAPI/Services/UserServices/IUserService.cs
+++ b/src/MercuriusAPI/Services/UserServices/IUserService.cs
@@ -5,6 +5,7 @@ namespace Mercurius.LAN.API.Services.UserServices;
 public interface IUserService
 {
     Task<GetUserDTO> CreateUserAsync(CreateUserProfileRequest request);
+    Task<GetUserDTO> CreateCurrentUserAsync(string auth0UserId, CompleteUserProfileRequest request);
     Task<GetUserDTO> CompleteProfileAsync(string auth0UserId, CompleteUserProfileRequest request);
     Task<CurrentUserProfileResponse> GetCurrentUserAsync(string auth0UserId);
     Task<PublicUserProfileDTO> GetPublicUserProfileByUsernameAsync(string username);

--- a/src/MercuriusAPI/Services/UserServices/UserService.cs
+++ b/src/MercuriusAPI/Services/UserServices/UserService.cs
@@ -39,9 +39,24 @@ public class UserService : IUserService
         return new GetUserDTO(user);
     }
 
+    public async Task<GetUserDTO> CreateCurrentUserAsync(string auth0UserId, CompleteUserProfileRequest request)
+    {
+        var normalizedAuth0UserId = NormalizeAuth0UserId(auth0UserId);
+        if (await _dbContext.Users.AnyAsync(u => u.Auth0UserId == normalizedAuth0UserId))
+            throw new ValidationException("Current user profile already exists.");
+
+        var auth0Profile = await _auth0ManagementService.GetUserProfileAsync(normalizedAuth0UserId);
+        var user = await CreateIncompleteUserAsync(normalizedAuth0UserId, auth0Profile);
+
+        ApplyProfileUpdate(user, request.Username, request.Firstname, request.Lastname, request.DiscordId, request.SteamId, request.RiotId);
+
+        await SaveProfileChangesAsync();
+        return new GetUserDTO(user);
+    }
+
     public async Task<GetUserDTO> CompleteProfileAsync(string auth0UserId, CompleteUserProfileRequest request)
     {
-        var user = await GetOrCreateCurrentUserAsync(auth0UserId);
+        var user = await GetRequiredCurrentUserAsync(auth0UserId);
         EnsureActive(user);
 
         ApplyProfileUpdate(user, request.Username, request.Firstname, request.Lastname, request.DiscordId, request.SteamId, request.RiotId);
@@ -52,10 +67,8 @@ public class UserService : IUserService
 
     public async Task<CurrentUserProfileResponse> GetCurrentUserAsync(string auth0UserId)
     {
-        var user = await GetOrCreateCurrentUserAsync(auth0UserId);
+        var user = await GetRequiredCurrentUserAsync(auth0UserId);
         EnsureActive(user);
-
-        await _dbContext.SaveChangesAsync();
 
         return new CurrentUserProfileResponse(user.IsComplete, new GetUserDTO(user));
     }
@@ -317,21 +330,6 @@ public class UserService : IUserService
 
         user.Anonymize(DateTime.UtcNow);
         await _dbContext.SaveChangesAsync();
-    }
-
-    private async Task<User> GetOrCreateCurrentUserAsync(string auth0UserId)
-    {
-        var normalizedAuth0UserId = NormalizeAuth0UserId(auth0UserId);
-        var auth0Profile = await _auth0ManagementService.GetUserProfileAsync(normalizedAuth0UserId);
-        var user = await _dbContext.Users.FirstOrDefaultAsync(u => u.Auth0UserId == normalizedAuth0UserId);
-
-        if (user == null)
-            return await CreateIncompleteUserAsync(normalizedAuth0UserId, auth0Profile);
-
-        if (!user.IsDeleted)
-            user.SyncAuth0Profile(auth0Profile.Email, auth0Profile.EmailVerified, DateTime.UtcNow);
-
-        return user;
     }
 
     private async Task<User> GetRequiredCurrentUserAsync(string auth0UserId)

--- a/src/MercuriusAPI/Services/UserServices/UserValidationService.cs
+++ b/src/MercuriusAPI/Services/UserServices/UserValidationService.cs
@@ -26,6 +26,15 @@ public class UserValidationService : IUserService
         return _inner.CreateUserAsync(request);
     }
 
+    public Task<GetUserDTO> CreateCurrentUserAsync(string auth0UserId, CompleteUserProfileRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(auth0UserId))
+            throw new ValidationException("Auth0 user id is required.");
+
+        ValidateProfileRequest(request.Username, request.Firstname, request.Lastname, request.DiscordId, request.SteamId, request.RiotId);
+        return _inner.CreateCurrentUserAsync(auth0UserId, request);
+    }
+
     public Task<GetUserDTO> CompleteProfileAsync(string auth0UserId, CompleteUserProfileRequest request)
     {
         if (string.IsNullOrWhiteSpace(auth0UserId))

--- a/tests/MercuriusAPI.Tests/UserEndpointRouteTests.cs
+++ b/tests/MercuriusAPI.Tests/UserEndpointRouteTests.cs
@@ -40,6 +40,18 @@ public class UserEndpointRouteTests
         Assert.Contains(endpoint.Metadata, metadata => metadata is IAuthorizeData);
     }
 
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("PUT")]
+    [InlineData("PATCH")]
+    public void CurrentUserProfileRoutes_RequireAuthorization(string method)
+    {
+        var endpoint = GetUserRouteEndpoint(method, "v{version:apiVersion}/lan/users/me");
+
+        Assert.DoesNotContain(endpoint.Metadata, metadata => metadata is IAllowAnonymous);
+        Assert.Contains(endpoint.Metadata, metadata => metadata is IAuthorizeData);
+    }
+
     [Fact]
     public void UserCollectionRoute_UsesAuthenticatedSearchRateLimitPolicy()
     {

--- a/tests/MercuriusAPI.Tests/UserTests.cs
+++ b/tests/MercuriusAPI.Tests/UserTests.cs
@@ -303,6 +303,25 @@ public class UserTests
     }
 
     [Fact]
+    public async Task CreateCurrentUserAsync_ForwardsSubjectAndProfileRequest()
+    {
+        var inner = new RecordingUserService();
+        var service = new UserValidationService(inner);
+        var request = new CompleteUserProfileRequest
+        {
+            Username = "ValidUser",
+            Firstname = "Player",
+            Lastname = "One"
+        };
+
+        var result = await service.CreateCurrentUserAsync("auth0|123", request);
+
+        Assert.Same(inner.CreatedUser, result);
+        Assert.Equal("auth0|123", inner.LastCreateCurrentSubject);
+        Assert.Same(request, inner.LastCreateCurrentRequest);
+    }
+
+    [Fact]
     public async Task CompleteProfileAsync_ForwardsSubjectAndProfileRequest()
     {
         var inner = new RecordingUserService();
@@ -444,6 +463,183 @@ public class UserTests
         var exception = await Assert.ThrowsAsync<NotFoundException>(() => service.DeleteUserAsync("missinguser"));
 
         Assert.Contains("missinguser", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserAsync_ReturnsExistingUserWithoutCreatingOrSyncingAuth0Profile()
+    {
+        await using var dbContext = CreateDbContext();
+        var user = CreateStoredUser("auth0|current", "stored@example.com");
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        var auth0ManagementService = new RecordingAuth0ManagementService(
+            new Auth0ProfileSnapshot("fresh@example.com", true, true));
+        var service = new UserService(dbContext, auth0ManagementService);
+
+        var response = await service.GetCurrentUserAsync("auth0|current");
+
+        Assert.True(response.IsComplete);
+        Assert.Equal(user.Id, response.User?.Id);
+        Assert.Equal("stored@example.com", response.Email);
+        Assert.False(response.EmailVerified);
+        Assert.Equal(0, auth0ManagementService.GetUserProfileCallCount);
+
+        var storedUser = await dbContext.Users.SingleAsync(u => u.Id == user.Id);
+        Assert.Equal("stored@example.com", storedUser.Email);
+        Assert.False(storedUser.EmailVerified);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserAsync_ThrowsNotFoundWithoutCreatingUser_WhenCurrentUserMissing()
+    {
+        await using var dbContext = CreateDbContext();
+        var auth0ManagementService = new RecordingAuth0ManagementService(
+            new Auth0ProfileSnapshot("fresh@example.com", true, true));
+        var service = new UserService(dbContext, auth0ManagementService);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => service.GetCurrentUserAsync("auth0|missing"));
+
+        Assert.Equal(0, auth0ManagementService.GetUserProfileCallCount);
+        Assert.Empty(await dbContext.Users.ToListAsync());
+    }
+
+    [Fact]
+    public async Task CreateCurrentUserAsync_CreatesMissingCurrentUserFromAuthenticatedSubject()
+    {
+        await using var dbContext = CreateDbContext();
+        var auth0ManagementService = new RecordingAuth0ManagementService(
+            new Auth0ProfileSnapshot("fresh@example.com", true, true));
+        var service = new UserService(dbContext, auth0ManagementService);
+        var request = new CompleteUserProfileRequest
+        {
+            Username = "NewPlayer",
+            Firstname = "New",
+            Lastname = "Player",
+            DiscordId = "discord-1"
+        };
+
+        var created = await service.CreateCurrentUserAsync(" auth0|new ", request);
+
+        Assert.Equal("NewPlayer", created.Username);
+        Assert.Equal("fresh@example.com", created.Email);
+        Assert.True(created.EmailVerified);
+        Assert.Equal(1, auth0ManagementService.GetUserProfileCallCount);
+        Assert.Equal("auth0|new", auth0ManagementService.LastGetUserProfileAuth0UserId);
+
+        var storedUser = await dbContext.Users.SingleAsync();
+        Assert.Equal("auth0|new", storedUser.Auth0UserId);
+        Assert.Equal("NewPlayer", storedUser.Username);
+        Assert.Equal("newplayer", storedUser.NormalizedUsername);
+        Assert.Equal("fresh@example.com", storedUser.Email);
+        Assert.Equal("discord-1", storedUser.DiscordId);
+    }
+
+    [Fact]
+    public async Task CreateCurrentUserAsync_RejectsExistingCurrentUserWithoutOverwritingProfile()
+    {
+        await using var dbContext = CreateDbContext();
+        var user = CreateStoredUser("auth0|existing", "stored@example.com");
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        var auth0ManagementService = new RecordingAuth0ManagementService(
+            new Auth0ProfileSnapshot("fresh@example.com", true, true));
+        var service = new UserService(dbContext, auth0ManagementService);
+        var request = new CompleteUserProfileRequest
+        {
+            Username = "OtherUser",
+            Firstname = "Other",
+            Lastname = "User"
+        };
+
+        var exception = await Assert.ThrowsAsync<ValidationException>(() =>
+            service.CreateCurrentUserAsync("auth0|existing", request));
+
+        Assert.Equal("Current user profile already exists.", exception.Message);
+        Assert.Equal(0, auth0ManagementService.GetUserProfileCallCount);
+
+        var storedUser = await dbContext.Users.SingleAsync(u => u.Id == user.Id);
+        Assert.Equal("PlayerOne", storedUser.Username);
+        Assert.Equal("stored@example.com", storedUser.Email);
+    }
+
+    [Fact]
+    public async Task CompleteProfileAsync_UpdatesExistingCurrentUserWithoutCallingAuth0Profile()
+    {
+        await using var dbContext = CreateDbContext();
+        var user = CreateStoredUser("auth0|existing", "stored@example.com");
+        user.Username = null;
+        user.NormalizedUsername = null;
+        user.Firstname = null;
+        user.Lastname = null;
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        var auth0ManagementService = new RecordingAuth0ManagementService(
+            new Auth0ProfileSnapshot("fresh@example.com", true, true));
+        var service = new UserService(dbContext, auth0ManagementService);
+        var request = new CompleteUserProfileRequest
+        {
+            Username = "CompletedUser",
+            Firstname = "Completed",
+            Lastname = "User",
+            SteamId = "steam-1"
+        };
+
+        var completed = await service.CompleteProfileAsync("auth0|existing", request);
+
+        Assert.Equal("CompletedUser", completed.Username);
+        Assert.Equal("stored@example.com", completed.Email);
+        Assert.False(completed.EmailVerified);
+        Assert.Equal(0, auth0ManagementService.GetUserProfileCallCount);
+
+        var storedUser = await dbContext.Users.SingleAsync(u => u.Id == user.Id);
+        Assert.Equal("CompletedUser", storedUser.Username);
+        Assert.Equal("completeduser", storedUser.NormalizedUsername);
+        Assert.Equal("Completed", storedUser.Firstname);
+        Assert.Equal("User", storedUser.Lastname);
+        Assert.Equal("steam-1", storedUser.SteamId);
+        Assert.Equal("stored@example.com", storedUser.Email);
+    }
+
+    [Fact]
+    public async Task CompleteProfileAsync_ThrowsNotFoundWithoutCreatingUser_WhenCurrentUserMissing()
+    {
+        await using var dbContext = CreateDbContext();
+        var auth0ManagementService = new RecordingAuth0ManagementService(
+            new Auth0ProfileSnapshot("fresh@example.com", true, true));
+        var service = new UserService(dbContext, auth0ManagementService);
+        var request = new CompleteUserProfileRequest
+        {
+            Username = "ValidUser",
+            Firstname = "Valid",
+            Lastname = "User"
+        };
+
+        await Assert.ThrowsAsync<NotFoundException>(() => service.CompleteProfileAsync("auth0|missing", request));
+
+        Assert.Equal(0, auth0ManagementService.GetUserProfileCallCount);
+        Assert.Empty(await dbContext.Users.ToListAsync());
+    }
+
+    [Fact]
+    public async Task UpdateCurrentUserAsync_ThrowsNotFoundWithoutCreatingUser_WhenCurrentUserMissing()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = new UserService(
+            dbContext,
+            new RecordingAuth0ManagementService(new Auth0ProfileSnapshot("fresh@example.com", true, true)));
+        var request = new UpdateUserProfileRequest
+        {
+            Username = "ValidUser",
+            Firstname = "Valid",
+            Lastname = "User"
+        };
+
+        await Assert.ThrowsAsync<NotFoundException>(() => service.UpdateCurrentUserAsync("auth0|missing", request));
+
+        Assert.Empty(await dbContext.Users.ToListAsync());
     }
 
     [Fact]
@@ -761,6 +957,8 @@ public class UserTests
     private sealed class RecordingUserService : IUserService
     {
         public CreateUserProfileRequest? LastCreateRequest { get; private set; }
+        public string? LastCreateCurrentSubject { get; private set; }
+        public CompleteUserProfileRequest? LastCreateCurrentRequest { get; private set; }
         public string? LastCompleteSubject { get; private set; }
         public CompleteUserProfileRequest? LastCompleteRequest { get; private set; }
         public string? LastUpdateCurrentSubject { get; private set; }
@@ -819,6 +1017,13 @@ public class UserTests
         public Task<GetUserDTO> CreateUserAsync(CreateUserProfileRequest request)
         {
             LastCreateRequest = request;
+            return Task.FromResult(CreatedUser);
+        }
+
+        public Task<GetUserDTO> CreateCurrentUserAsync(string auth0UserId, CompleteUserProfileRequest request)
+        {
+            LastCreateCurrentSubject = auth0UserId;
+            LastCreateCurrentRequest = request;
             return Task.FromResult(CreatedUser);
         }
 
@@ -884,9 +1089,13 @@ public class UserTests
         }
 
         public string? LastPasswordResetEmail { get; private set; }
+        public string? LastGetUserProfileAuth0UserId { get; private set; }
+        public int GetUserProfileCallCount { get; private set; }
 
         public Task<Auth0ProfileSnapshot> GetUserProfileAsync(string auth0UserId, CancellationToken cancellationToken = default)
         {
+            LastGetUserProfileAuth0UserId = auth0UserId;
+            GetUserProfileCallCount++;
             return Task.FromResult(_profileSnapshot);
         }
 


### PR DESCRIPTION
## Summary

- Split authenticated current-user profile behavior so `GET /v1/lan/users/me` is read-only.
- Added `PUT /v1/lan/users/me` for explicit current-user creation.
- Kept `PATCH /v1/lan/users/me` and `POST /v1/lan/users/me/complete-profile` as existing-user update paths.
- Added OpenSpec coverage and regression tests for missing-user, existing-user, and no-create/no-sync behavior.

## Why

`GET /me` was creating missing user rows and updating Auth0 profile snapshots during a read. This made a safe read endpoint mutate database state. The new flow makes creation and update intent explicit while preserving the legacy complete-profile route as an update-only compatibility path.

## Validation

- `openspec validate split-current-user-profile-writes`
- `dotnet build LAN.API.sln -p:UseAppHost=false`
- `dotnet test LAN.API.sln -p:UseAppHost=false` passed: 235/235

## Notes

- No database migration required.
- No CORS, Auth0, environment variable, or deployment configuration changes expected.
- Front-end clients should call `PUT /v1/lan/users/me` to create a missing current-user profile, then use `GET /me` for reads and `PATCH /me` or `POST /me/complete-profile` for existing profile updates.